### PR TITLE
fix(ui): polish onboarding, quiz, and chart logic

### DIFF
--- a/app/(intro)/intro.js
+++ b/app/(intro)/intro.js
@@ -14,6 +14,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { setSeenIntro } from "../../lib/storage/firstRun";
 import colors from "../../theme/colors";
 import { useHapticsUtils } from "../../utils/haptics";
@@ -53,10 +54,12 @@ const SLIDES = [
 export default function IntroPage() {
   const router = useRouter();
   const { hapticPress } = useHapticsUtils();
+  const insets = useSafeAreaInsets();
   const [currentIndex, setCurrentIndex] = useState(0);
   const flatListRef = useRef(null);
 
   const isLastSlide = currentIndex === SLIDES.length - 1;
+  const skipTopOffset = Math.max((insets.top || 0) + 12, 40);
 
   const handleNext = async () => {
     await hapticPress();
@@ -112,7 +115,13 @@ export default function IntroPage() {
     <View style={styles.container}>
       {/* Skip button */}
       {!isLastSlide && (
-        <TouchableOpacity style={styles.skipButton} onPress={handleSkip}>
+        <TouchableOpacity
+          style={[
+            styles.skipButton,
+            { top: skipTopOffset },
+          ]}
+          onPress={handleSkip}
+        >
           <Text style={styles.skipText}>Skip</Text>
         </TouchableOpacity>
       )}
@@ -150,7 +159,6 @@ const styles = StyleSheet.create({
   },
   skipButton: {
     position: "absolute",
-    top: 50,
     right: 20,
     zIndex: 10,
     paddingVertical: 8,

--- a/components/challenges/ChallengeCard/index.js
+++ b/components/challenges/ChallengeCard/index.js
@@ -50,7 +50,7 @@ const ChallengeCard = ({
   };
 
   return (
-    <View style={styles.card}>
+    <Pressable onPress={onInfoPress} style={styles.card}>
       <View style={styles.topRow}>
         <View style={styles.leftColumn}>
           <Pressable onPress={handleTickPress}>
@@ -119,7 +119,7 @@ const ChallengeCard = ({
           }}
         />
       )}
-    </View>
+    </Pressable>
   );
 };
 

--- a/components/challenges/FeaturedChallengeCard/index.js
+++ b/components/challenges/FeaturedChallengeCard/index.js
@@ -186,6 +186,18 @@ const FeaturedChallengeCard = ({ onActivateChallenge, activeCount }) => {
           )
         }
       />
+
+      {/* Instructional hints */}
+      <View style={styles.swipeHints}>
+        <View style={styles.hintLeft}>
+          <MaterialIcons name="arrow-back" size={20} color="#EF4444" />
+          <Text style={styles.hintText}>Swipe left to skip</Text>
+        </View>
+        <View style={styles.hintRight}>
+          <Text style={styles.hintText}>Swipe right to accept</Text>
+          <MaterialIcons name="arrow-forward" size={20} color="#22C55E" />
+        </View>
+      </View>
     </View>
   );
 };

--- a/components/challenges/FeaturedChallengeCard/styles.js
+++ b/components/challenges/FeaturedChallengeCard/styles.js
@@ -147,4 +147,32 @@ export default StyleSheet.create({
     elevation: 1,
     opacity: 0.6,
   },
+
+  // Swipe hints at the bottom
+  swipeHints: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    width: "90%",
+    marginTop: 12,
+    paddingHorizontal: 8,
+  },
+
+  hintLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+
+  hintRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+
+  hintText: {
+    fontSize: 13,
+    fontWeight: "500",
+    color: "#6B7280",
+  },
 });

--- a/components/profile/ScoreCard/CarbonCard.js
+++ b/components/profile/ScoreCard/CarbonCard.js
@@ -17,19 +17,45 @@ import styles from "./styles";
  * @param {Object} props.data - Data for the carbon score card.
  * @param {string} props.data.title - Title of the card.
  * @param {number} props.data.value - Carbon points value.
+ * @param {number} [props.data.progress] - Progress ratio (legacy support).
  * @param {{ name: string }} props.data.icon - Icon object.
  * @returns {JSX.Element}
  */
+const MAX_POINTS_FALLBACK = 1000; // Used when value is missing but progress is provided
+const POINTS_PER_RING = 500;
+
 const CarbonCard = ({ data }) => {
-  const points = data.value || 0;
+  if (!data) return null;
+
+  const parsedValue = Number(data.value);
+  const fallbackPoints =
+    typeof data.progress === "number"
+      ? Math.round(Math.max(data.progress, 0) * MAX_POINTS_FALLBACK)
+      : 0;
+
+  const points = Math.max(
+    Number.isFinite(parsedValue) ? parsedValue : fallbackPoints,
+    0
+  );
   const levelTier = getLevelTier(points);
-  const stage = Math.floor(points / 500) + 1; // Updated: 500 points per ring
-  const pointsToNextMilestone = 500 - (points % 500); // Updated: 500 points per ring
+  const stage = Math.floor(points / POINTS_PER_RING) + 1;
+  const pointsIntoCurrentRing = points % POINTS_PER_RING;
+  const pointsToNextMilestone =
+    pointsIntoCurrentRing === 0 ? POINTS_PER_RING : POINTS_PER_RING - pointsIntoCurrentRing;
+  const levelText = data.level?.text || levelTier.name;
 
   return (
     <View style={styles.carbon.card}>
-      {/* Header - no icon per requirement */}
+      {/* Header */}
       <View style={styles.carbon.header}>
+        {data.icon?.name && (
+          <MaterialIcons
+            name={data.icon.name}
+            size={20}
+            color={colors.eco.yellow}
+            style={{ marginRight: 8 }}
+          />
+        )}
         <Text style={styles.carbon.title}>{data.title}</Text>
       </View>
 
@@ -45,7 +71,7 @@ const CarbonCard = ({ data }) => {
           points={points}
           size={120}
           strokeWidth={10}
-          maxPerRing={500}
+          maxPerRing={POINTS_PER_RING}
         >
           {/* Centered Stage badge design */}
           <View style={styles.carbon.stageBadge}>
@@ -58,10 +84,18 @@ const CarbonCard = ({ data }) => {
 
       {/* Level row with subtitle */}
       <View style={styles.carbon.levelRow}>
+        {data.level?.icon?.name && (
+          <MaterialIcons
+            name={data.level.icon.name}
+            size={18}
+            color={colors.eco.purple}
+            style={{ marginRight: 6 }}
+          />
+        )}
         <View style={styles.carbon.levelTextContainer}>
-          <Text style={styles.carbon.levelText}>{levelTier.name}</Text>
+          <Text style={styles.carbon.levelText}>{levelText}</Text>
           <Text style={styles.carbon.levelSubtitle}>
-            Stage {stage} · {levelTier.min}-{levelTier.max === Infinity ? '∞' : levelTier.max} pts
+            Stage {stage} · {levelTier.min}-{levelTier.max === Infinity ? "∞" : levelTier.max} pts
           </Text>
         </View>
       </View>

--- a/components/profile/ScoreCard/CarbonCard.js
+++ b/components/profile/ScoreCard/CarbonCard.js
@@ -1,13 +1,17 @@
 /**
  * @fileoverview CarbonCard component.
  * Displays carbon points with tree-ring progress visualization and level.
+ * Adds SharePosterModal integration (top-right share icon).
  */
 
-import { MaterialIcons } from "@expo/vector-icons";
-import { Text, View } from "react-native";
+import { Ionicons, MaterialIcons } from "@expo/vector-icons";
+import { useState } from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+import { useUser } from "../../../context/UserContext";
 import colors from "../../../theme/colors";
 import TreeRingProgress from "../../progress/TreeRingProgress";
 import { getLevelTier } from "../../../utils/levelTiers";
+import SharePosterModal from "../../rewards/SharePosterModal/index";
 import styles from "./styles";
 
 /**
@@ -25,6 +29,9 @@ const MAX_POINTS_FALLBACK = 1000; // Used when value is missing but progress is 
 const POINTS_PER_RING = 500;
 
 const CarbonCard = ({ data }) => {
+  const [showShareModal, setShowShareModal] = useState(false);
+  const { user } = useUser();
+
   if (!data) return null;
 
   const parsedValue = Number(data.value);
@@ -43,6 +50,12 @@ const CarbonCard = ({ data }) => {
   const pointsToNextMilestone =
     pointsIntoCurrentRing === 0 ? POINTS_PER_RING : POINTS_PER_RING - pointsIntoCurrentRing;
   const levelText = data.level?.text || levelTier.name;
+  const co2SavedKg = Number.isFinite(points)
+    ? Number((points / 18).toFixed(1))
+    : 0;
+  const username = user?.name || "Verde User";
+  const handleOpenShare = () => setShowShareModal(true);
+  const handleCloseShare = () => setShowShareModal(false);
 
   return (
     <View style={styles.carbon.card}>
@@ -57,6 +70,17 @@ const CarbonCard = ({ data }) => {
           />
         )}
         <Text style={styles.carbon.title}>{data.title}</Text>
+        <TouchableOpacity
+          style={styles.carbon.shareIcon}
+          onPress={handleOpenShare}
+          activeOpacity={0.7}
+        >
+          <Ionicons
+            name="share-outline"
+            size={22}
+            color={colors.eco.green[600]}
+          />
+        </TouchableOpacity>
       </View>
 
       {/* Points display and tree ring visualization */}
@@ -111,6 +135,16 @@ const CarbonCard = ({ data }) => {
           Earn {pointsToNextMilestone} pts more to unlock next stage!
         </Text>
       </View>
+
+      <SharePosterModal
+        visible={showShareModal}
+        onClose={handleCloseShare}
+        points={points}
+        co2SavedKg={co2SavedKg}
+        badgeName={levelTier.name}
+        username={username}
+        dateRangeLabel="this month"
+      />
     </View>
   );
 };

--- a/components/profile/ScoreCard/CarbonCard.js
+++ b/components/profile/ScoreCard/CarbonCard.js
@@ -1,150 +1,69 @@
 /**
  * @fileoverview CarbonCard component.
- * Displays carbon points with tree-ring progress visualization and level.
- * Adds SharePosterModal integration (top-right share icon).
+ * Displays carbon points with progress circle and level.
  */
 
-import { Ionicons, MaterialIcons } from "@expo/vector-icons";
-import { useState } from "react";
-import { Text, TouchableOpacity, View } from "react-native";
-import { useUser } from "../../../context/UserContext";
+import { MaterialIcons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
 import colors from "../../../theme/colors";
-import TreeRingProgress from "../../progress/TreeRingProgress";
-import { getLevelTier } from "../../../utils/levelTiers";
-import SharePosterModal from "../../rewards/SharePosterModal/index";
+import ProgressCircle from "../../ProgressCircle";
 import styles from "./styles";
 
 /**
- * CarbonCard for displaying carbon score with tree-ring visualization.
+ * CarbonCard for displaying carbon score.
  *
  * @param {Object} props
  * @param {Object} props.data - Data for the carbon score card.
  * @param {string} props.data.title - Title of the card.
  * @param {number} props.data.value - Carbon points value.
- * @param {number} [props.data.progress] - Progress ratio (legacy support).
+ * @param {number} props.data.progress - Progress ratio (0–1).
  * @param {{ name: string }} props.data.icon - Icon object.
+ * @param {{ icon: { name: string }, text: string }} props.data.level - Level info.
  * @returns {JSX.Element}
  */
-const MAX_POINTS_FALLBACK = 1000; // Used when value is missing but progress is provided
-const POINTS_PER_RING = 500;
-
 const CarbonCard = ({ data }) => {
-  const [showShareModal, setShowShareModal] = useState(false);
-  const { user } = useUser();
-
   if (!data) return null;
-
-  const parsedValue = Number(data.value);
-  const fallbackPoints =
-    typeof data.progress === "number"
-      ? Math.round(Math.max(data.progress, 0) * MAX_POINTS_FALLBACK)
-      : 0;
-
-  const points = Math.max(
-    Number.isFinite(parsedValue) ? parsedValue : fallbackPoints,
-    0
-  );
-  const levelTier = getLevelTier(points);
-  const stage = Math.floor(points / POINTS_PER_RING) + 1;
-  const pointsIntoCurrentRing = points % POINTS_PER_RING;
-  const pointsToNextMilestone =
-    pointsIntoCurrentRing === 0 ? POINTS_PER_RING : POINTS_PER_RING - pointsIntoCurrentRing;
-  const levelText = data.level?.text || levelTier.name;
-  const co2SavedKg = Number.isFinite(points)
-    ? Number((points / 18).toFixed(1))
-    : 0;
-  const username = user?.name || "Verde User";
-  const handleOpenShare = () => setShowShareModal(true);
-  const handleCloseShare = () => setShowShareModal(false);
 
   return (
     <View style={styles.carbon.card}>
-      {/* Header */}
       <View style={styles.carbon.header}>
         {data.icon?.name && (
           <MaterialIcons
             name={data.icon.name}
             size={20}
             color={colors.eco.yellow}
-            style={{ marginRight: 8 }}
           />
         )}
         <Text style={styles.carbon.title}>{data.title}</Text>
-        <TouchableOpacity
-          style={styles.carbon.shareIcon}
-          onPress={handleOpenShare}
-          activeOpacity={0.7}
-        >
-          <Ionicons
-            name="share-outline"
-            size={22}
-            color={colors.eco.green[600]}
-          />
-        </TouchableOpacity>
       </View>
 
-      {/* Points display and tree ring visualization */}
       <View style={styles.carbon.mainRow}>
-        <View style={styles.carbon.pointsContainer}>
-          <Text style={styles.carbon.value}>{String(points)}</Text>
-          <Text style={styles.carbon.pointsLabel}>Carbon Points</Text>
-        </View>
-
-        {/* Tree-Ring Progress with 500 points per ring */}
-        <TreeRingProgress
-          points={points}
-          size={120}
-          strokeWidth={10}
-          maxPerRing={POINTS_PER_RING}
-        >
-          {/* Centered Stage badge design */}
-          <View style={styles.carbon.stageBadge}>
-            <Text style={styles.carbon.stageBadgeText}>
-              Stage {stage}
+        <Text style={styles.carbon.value}>{String(data.value)}</Text>
+        {typeof data.progress === "number" && (
+          <ProgressCircle
+            key={data.progress}
+            progress={data.progress}
+            size={72}
+            strokeWidth={6}
+            color={colors.eco.green[600]}
+          >
+            <Text style={styles.carbon.percentText}>
+              {Math.round(data.progress * 100)}%
             </Text>
-          </View>
-        </TreeRingProgress>
+          </ProgressCircle>
+        )}
       </View>
 
-      {/* Level row with subtitle */}
-      <View style={styles.carbon.levelRow}>
-        {data.level?.icon?.name && (
+      {data.level?.icon?.name && data.level?.text && (
+        <View style={styles.carbon.levelRow}>
           <MaterialIcons
             name={data.level.icon.name}
             size={18}
             color={colors.eco.purple}
-            style={{ marginRight: 6 }}
           />
-        )}
-        <View style={styles.carbon.levelTextContainer}>
-          <Text style={styles.carbon.levelText}>{levelText}</Text>
-          <Text style={styles.carbon.levelSubtitle}>
-            Stage {stage} · {levelTier.min}-{levelTier.max === Infinity ? "∞" : levelTier.max} pts
-          </Text>
+          <Text style={styles.carbon.levelText}>{data.level.text}</Text>
         </View>
-      </View>
-
-      {/* Next reward hint with eco-themed icon */}
-      <View style={styles.carbon.rewardHint}>
-        <MaterialIcons
-          name="emoji-events"
-          size={16}
-          color={colors.eco.green[700]}
-        />
-        <Text style={styles.carbon.rewardText}>
-          Earn {pointsToNextMilestone} pts more to unlock next stage!
-        </Text>
-      </View>
-
-      <SharePosterModal
-        visible={showShareModal}
-        onClose={handleCloseShare}
-        points={points}
-        co2SavedKg={co2SavedKg}
-        badgeName={levelTier.name}
-        username={username}
-        dateRangeLabel="this month"
-      />
+      )}
     </View>
   );
 };

--- a/components/profile/ScoreCard/CarbonCard.js
+++ b/components/profile/ScoreCard/CarbonCard.js
@@ -58,11 +58,6 @@ const CarbonCard = ({ data }) => {
 
       {/* Level row with subtitle */}
       <View style={styles.carbon.levelRow}>
-        <MaterialIcons
-          name="eco"
-          size={20}
-          color={colors.eco.green[600]}
-        />
         <View style={styles.carbon.levelTextContainer}>
           <Text style={styles.carbon.levelText}>{levelTier.name}</Text>
           <Text style={styles.carbon.levelSubtitle}>

--- a/components/profile/ScoreCard/styles.js
+++ b/components/profile/ScoreCard/styles.js
@@ -40,7 +40,7 @@ const base = StyleSheet.create({
 const carbon = StyleSheet.create({
   card: {
     borderRadius: 16,
-    padding: 20,
+    padding: 16,
     marginBottom: 20,
     backgroundColor: colors.neutral.white,
     shadowColor: "#000",
@@ -51,101 +51,35 @@ const carbon = StyleSheet.create({
   header: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 16,
+    marginBottom: 12,
   },
   title: {
     fontSize: 16,
     fontWeight: "700",
+    marginLeft: 6,
     color: colors.textPrimary,
   },
   mainRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 16,
-    paddingBottom: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.neutral.gray100,
+    marginBottom: 8,
   },
-  pointsContainer: {
-    flex: 1,
-    justifyContent: "center",
-  },
-  value: {
-    fontSize: 40,
-    fontWeight: "800",
-    color: colors.textPrimary,
-    lineHeight: 48,
-  },
-  pointsLabel: {
-    fontSize: 14,
-    fontWeight: "500",
-    color: colors.textSecondary,
-    marginTop: 4,
-  },
-  stageBadge: {
-    backgroundColor: colors.eco.green[600],
-    paddingHorizontal: 6, // Reduced from 8
-    paddingVertical: 3, // Reduced from 4
-    borderRadius: 10,
-    borderWidth: 2,
-    borderColor: colors.neutral.white,
-    shadowColor: "#000",
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    shadowOffset: { width: 0, height: 2 },
-    elevation: 3,
-  },
-  stageBadgeText: {
-    fontSize: 10,
-    fontWeight: "700",
-    color: colors.neutral.white,
-    letterSpacing: 0.5,
-  },
+  left: { flex: 1, justifyContent: "center" },
+  right: { justifyContent: "center", alignItems: "center" },
+  value: { fontSize: 34, fontWeight: "700", color: colors.textPrimary },
+  percentText: { fontSize: 13, fontWeight: "600", color: colors.textSecondary },
   levelRow: {
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
-    marginTop: 12,
-    marginBottom: 12,
-  },
-  levelTextContainer: {
-    alignItems: "center",
+    marginTop: 8,
   },
   levelText: {
-    fontSize: 16,
-    fontWeight: "700",
-    color: colors.eco.green[700],
-  },
-  levelSubtitle: {
-    fontSize: 11,
-    fontWeight: "500",
-    color: colors.neutral.gray400, // Lighter grey
-    marginTop: 2,
-  },
-  rewardHint: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: colors.eco.green[50],
-    paddingVertical: 4,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    marginTop: 4,
-  },
-  rewardText: {
-    fontSize: 12,
+    fontSize: 14,
     fontWeight: "600",
-    color: colors.eco.green[700],
+    color: colors.eco.purple,
     marginLeft: 6,
-  },
-  shareIcon: {
-    marginLeft: "auto",
-    padding: 6,
-    borderRadius: 999,
-    backgroundColor: colors.eco.green[100],
-    alignItems: "center",
-    justifyContent: "center",
   },
 });
 

--- a/components/profile/ScoreCard/styles.js
+++ b/components/profile/ScoreCard/styles.js
@@ -110,7 +110,6 @@ const carbon = StyleSheet.create({
     marginBottom: 12,
   },
   levelTextContainer: {
-    marginLeft: 6,
     alignItems: "center",
   },
   levelText: {

--- a/components/profile/ScoreCard/styles.js
+++ b/components/profile/ScoreCard/styles.js
@@ -139,6 +139,14 @@ const carbon = StyleSheet.create({
     color: colors.eco.green[700],
     marginLeft: 6,
   },
+  shareIcon: {
+    marginLeft: "auto",
+    padding: 6,
+    borderRadius: 999,
+    backgroundColor: colors.eco.green[100],
+    alignItems: "center",
+    justifyContent: "center",
+  },
 });
 
 export default { base, carbon };

--- a/components/tracking/ImpactChart/index.js
+++ b/components/tracking/ImpactChart/index.js
@@ -15,7 +15,6 @@ import Svg, {
 } from "react-native-svg";
 
 import colors from "../../../theme/colors";
-import RangeSwitch from "../RangeSwitch";
 import styles from "./styles";
 import {
   startEndForLastNDays,
@@ -35,8 +34,10 @@ const MISSING_COLOR = "rgba(2,6,23,0.20)";
 const CHART_HEIGHT = 168;
 const CHART_VERTICAL_PADDING = 20;
 const CHART_HORIZONTAL_PADDING = 16;
+const POINT_GUTTER_LEFT = 1;
+const POINT_GUTTER_RIGHT = 24;
 const GRID_LINE_COUNT = 4;
-const AXIS_LABEL_WIDTH = 48;
+const AXIS_LABEL_WIDTH = 60;
 const TOOLTIP_HEIGHT = 52;
 
 const formatNumber = (value) => {
@@ -64,9 +65,7 @@ const formatValue = (value) => `${formatNumber(value)} kg CO₂`;
 
 const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
   const [containerWidth, setContainerWidth] = useState(0);
-  const [range, setRange] = useState("7D"); // Default to 7 days
-
-  const RANGE_N = range === "7D" ? 7 : 30;
+  const RANGE_N = 7;
 
   // Calculate N-day window ending today
   const { start, end } = useMemo(() => startEndForLastNDays(RANGE_N), [RANGE_N]);
@@ -112,29 +111,31 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
     return padded > 0 ? padded : 1;
   }, [baselinePerDay, series]);
 
-  const plotWidth = useMemo(
-    () => Math.max(containerWidth - CHART_HORIZONTAL_PADDING * 2, 0),
-    [containerWidth]
-  );
+  const plotWidth = useMemo(() => {
+    const leftBound = CHART_HORIZONTAL_PADDING + POINT_GUTTER_LEFT;
+    const rightBound =
+      containerWidth - CHART_HORIZONTAL_PADDING - POINT_GUTTER_RIGHT;
+    return Math.max(rightBound - leftBound, 0);
+  }, [containerWidth]);
 
   const plotHeight = Math.max(CHART_HEIGHT - CHART_VERTICAL_PADDING * 2, 0);
 
   // Calculate chart points for line - use index-based positioning for perfect alignment
   const chartPoints = useMemo(() => {
-    if (!plotWidth || !series.length) return [];
+    if (!series.length) return [];
 
-    const step = series.length > 1 ? plotWidth / (series.length - 1) : plotWidth / 2;
+    const leftBound = CHART_HORIZONTAL_PADDING + POINT_GUTTER_LEFT;
+    const step = series.length > 1 ? plotWidth / (series.length - 1) : 0;
 
     return series.map((point, index) => {
       const value = point.value ?? 0;
       const normalized = Math.min(value / safeMax, 1);
       const y = CHART_VERTICAL_PADDING + (1 - normalized) * plotHeight;
+      const offset = series.length > 1 ? step * index : plotWidth / 2;
 
       return {
         ...point,
-        x:
-          CHART_HORIZONTAL_PADDING +
-          (series.length > 1 ? step * index : step),
+        x: leftBound + offset,
         y,
         normalized,
       };
@@ -238,17 +239,20 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
     const width = Math.max(128, maxChars * 7 + 24);
 
     // When active point is at the rightmost edge (Today), nudge tooltip left
-    const isRightmost = activePoint.x >= containerWidth - CHART_HORIZONTAL_PADDING - 20;
-    const x = isRightmost
-      ? containerWidth - CHART_HORIZONTAL_PADDING - width - 8
-      : Math.min(
-          Math.max(activePoint.x - width / 2, CHART_HORIZONTAL_PADDING),
-          containerWidth - CHART_HORIZONTAL_PADDING - width
-        );
+    const leftBound = CHART_HORIZONTAL_PADDING + POINT_GUTTER_LEFT;
+    const rightBound =
+      containerWidth - CHART_HORIZONTAL_PADDING - POINT_GUTTER_RIGHT;
+    const maxTooltipLeft = Math.max(rightBound - width, leftBound);
+    const clampedDefaultLeft = Math.min(
+      Math.max(activePoint.x - width / 2, leftBound),
+      maxTooltipLeft
+    );
+    const isRightmost = activePoint.x >= rightBound - 8;
+    const x = isRightmost ? maxTooltipLeft : clampedDefaultLeft;
 
     const pointerX = Math.min(
-      Math.max(activePoint.x, CHART_HORIZONTAL_PADDING + 12),
-      containerWidth - CHART_HORIZONTAL_PADDING - 12
+      Math.max(activePoint.x, leftBound),
+      rightBound
     );
     const y = Math.max(activePoint.y - 70, 10);
 
@@ -291,7 +295,7 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
     return series.reduce((sum, point) => sum + (point.value ?? 0), 0);
   }, [series]);
 
-  const rangeLabel = range === "30D" ? "Past 30 days" : "Past 7 days";
+  const rangeLabel = "Past 7 days";
 
   // Format date range caption (e.g., "1 Sep – 30 Sep")
   const dateRangeCaption = useMemo(() => {
@@ -304,15 +308,16 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
     return `${formatDate(start)} – ${formatDate(end)}`;
   }, [start, end]);
 
-  // For 7D view, show 3 labels (first/middle/Today); for 30D, show every 5 days + Today
+  // For 7D view, show every 2 days + Today; (30D not used but kept for safety)
   const shouldShowLabel = (index) => {
     const n = chartPoints.length;
     const idxToday = n - 1;
 
     if (RANGE_N === 7) {
-      // Show 3 ticks: first, middle, Today
-      const idxMiddle = Math.floor(n / 2);
-      return index === 0 || index === idxMiddle || index === idxToday;
+      if (index === idxToday) {
+        return true;
+      }
+      return index % 2 === 0;
     }
     if (RANGE_N === 30) {
       // Show every 5 days + Today (~7 ticks total)
@@ -347,9 +352,6 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
           <Text style={styles.metricValue}>{formatValue(rangeTotal)}</Text>
           <Text style={styles.dateRangeCaption}>{dateRangeCaption}</Text>
         </View>
-
-        {/* Range Selector Switch */}
-        <RangeSwitch value={range} onChange={setRange} />
       </View>
 
       <View style={styles.chartWrapper}>
@@ -414,20 +416,6 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
                   opacity={isAxis ? 1 : 0.7}
                 />
               ))}
-
-              {/* Baseline - Subtle dotted line for Daily target */}
-              {baselineY !== null && (
-                <Line
-                  x1={CHART_HORIZONTAL_PADDING}
-                  x2={containerWidth - CHART_HORIZONTAL_PADDING}
-                  y1={baselineY}
-                  y2={baselineY}
-                  stroke={BASELINE_COLOR}
-                  strokeWidth={1.2}
-                  strokeDasharray="2 4"
-                  opacity={0.5}
-                />
-              )}
 
               {/* Tooltip vertical line */}
               {tooltipConfig && (
@@ -560,18 +548,6 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
                     strokeWidth={1.2}
                     opacity={0.98}
                   />
-                  <Path
-                    d={`M ${tooltipConfig.pointerX} ${
-                      tooltipConfig.y + TOOLTIP_HEIGHT + 8
-                    } L ${tooltipConfig.pointerX + 7} ${
-                      tooltipConfig.y + TOOLTIP_HEIGHT
-                    } L ${tooltipConfig.pointerX - 7} ${
-                      tooltipConfig.y + TOOLTIP_HEIGHT
-                    } Z`}
-                    fill={colors.neutral.white}
-                    stroke={colors.eco.green[500]}
-                    strokeWidth={0.8}
-                  />
                   <SvgText
                     x={tooltipConfig.x + tooltipConfig.width / 2}
                     y={tooltipConfig.y + 20}
@@ -603,20 +579,12 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
               <Text style={styles.emptySubtitle}>
                 Once you record data today, your weekly insights will appear here.
               </Text>
-              <View style={styles.emptyBaseline}>
-                {series.slice(0, 7).map((point) => (
-                  <View key={point.dateKey} style={styles.emptyColumn}>
-                    <View style={styles.emptyIndicator} />
-                    <Text style={styles.emptyDay}>{point.label}</Text>
-                  </View>
-                ))}
-              </View>
             </View>
           )}
         </View>
 
         {/* X-axis labels */}
-        {containerWidth > 0 && chartPoints.length > 0 && (
+        {containerWidth > 0 && chartPoints.length > 0 && hasPositiveData && (
           <View style={[styles.labelsRow, { width: containerWidth }]}>
             {chartPoints.map((point, index) => {
               if (!shouldShowLabel(index)) return null;
@@ -627,8 +595,7 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
                   style={[
                     styles.axisLabel,
                     {
-                      left: point.x,
-                      transform: [{ translateX: -AXIS_LABEL_WIDTH / 2 }],
+                      left: point.x - AXIS_LABEL_WIDTH / 3.7,
                     },
                   ]}
                 >
@@ -660,16 +627,11 @@ const ImpactChart = ({ weeklyTrend = [], baseline = 0, total = 0 }) => {
           <View style={[styles.legendBullet, styles.legendBulletDaily]} />
           <Text style={styles.legendLabel}>Daily CO₂ emissions</Text>
         </View>
+        <View style={{ flex: 1 }} />
         <View style={styles.legendItem}>
           <View style={[styles.legendLine, styles.legendLineTrend]} />
           <Text style={styles.legendLabel}>Trend</Text>
         </View>
-        {baselinePerDay > 0 && (
-          <View style={styles.legendItem}>
-            <View style={[styles.legendLine, styles.legendLineBaseline]} />
-            <Text style={styles.legendLabel}>Daily target</Text>
-          </View>
-        )}
       </View>
     </View>
   );

--- a/components/tracking/ImpactChart/styles.js
+++ b/components/tracking/ImpactChart/styles.js
@@ -97,7 +97,7 @@ export default StyleSheet.create({
     width: "100%",
     height: 168,
     borderRadius: 16,
-    backgroundColor: colors.neutral.gray50,
+    backgroundColor: "rgba(22, 163, 74, 0.04)",
     paddingHorizontal: 16,
     paddingTop: 24,
     paddingBottom: 16,
@@ -185,27 +185,5 @@ export default StyleSheet.create({
     color: colors.textSecondary,
     textAlign: "center",
     marginTop: 6,
-  },
-  emptyBaseline: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "flex-end",
-    marginTop: 20,
-    width: "100%",
-  },
-  emptyColumn: {
-    alignItems: "center",
-    flex: 1,
-  },
-  emptyIndicator: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: colors.neutral.gray200,
-    marginBottom: 8,
-  },
-  emptyDay: {
-    fontSize: 12,
-    color: colors.textSecondary,
   },
 });


### PR DESCRIPTION
- Swap intro slides from SVG → PNG to fix blank render on devices without Metro SVG transformer
- Add SafeAreaInsets padding to Skip CTA on intro screen to prevent notch overlap
- Enable username/avatar display in PosterCard export for personalized share
- Fix QuizScreen background by adding missing `eco.blueSoft` token to color palette
- Guard JSON.parse in QuizScreen with try/catch to avoid crash on malformed/deep-link params
- Clamp pointsToNextMilestone to 0 at exact stage milestones in ScoreCard