### PR TITLE
Transport logging flow: cancel/back routes now return to Tracking wit…

### DIFF
--- a/app/(tabs)/ChallengePage.js
+++ b/app/(tabs)/ChallengePage.js
@@ -179,6 +179,9 @@ const ChallengePage = () => {
       >
         <View style={styles.headerSpacing}>
           <PageHeader title="Challenges" />
+          <Text style={styles.pageSubtitle}>
+            Pick actions to build lasting habits and earn extra points.
+          </Text>
         </View>
 
         <View style={styles.featuredWrapper}>
@@ -239,6 +242,11 @@ const styles = StyleSheet.create({
   },
   headerSpacing: {
     marginBottom: layout.sectionSpacing,
+  },
+  pageSubtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: colors.textSecondary,
   },
   featuredWrapper: {
     height: 300,

--- a/app/(tabs)/LearningPage.js
+++ b/app/(tabs)/LearningPage.js
@@ -661,7 +661,14 @@ const LearningPage = () => {
       ]}
       keyExtractor={(_, index) => `learning-section-${index}`}
       renderItem={({ item }) => item}
-      ListHeaderComponent={<PageHeader title="Learning Hub" />}
+      ListHeaderComponent={
+        <View style={styles.listHeader}>
+          <PageHeader title="Learning Hub" />
+          <Text style={styles.pageSubtitle}>
+            Discover tips, guides, and quizzes to inspire your next eco move.
+          </Text>
+        </View>
+      }
       contentContainerStyle={styles.container}
       showsVerticalScrollIndicator={false}
     />
@@ -669,6 +676,9 @@ const LearningPage = () => {
 };
 
 const styles = StyleSheet.create({
+  listHeader: {
+    marginBottom: layout.sectionSpacing,
+  },
   container: {
     paddingHorizontal: layout.screenPadding,
     paddingTop: layout.screenPadding,
@@ -697,6 +707,11 @@ const styles = StyleSheet.create({
     color: colors.textSecondary,
     maxWidth: 320,
     lineHeight: 20,
+  },
+  pageSubtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: colors.textSecondary,
   },
   sectionDividerInset: {
     height: 1,

--- a/app/(tabs)/ProfilePage.js
+++ b/app/(tabs)/ProfilePage.js
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
     paddingBottom: layout.blockSpacing,
   },
   headerSpacing: {
-    marginBottom: layout.sectionSpacing,
+    marginBottom: layout.cardSpacing,
   },
   pageSubtitle: {
     marginTop: 4,

--- a/app/(tabs)/ProfilePage.js
+++ b/app/(tabs)/ProfilePage.js
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { useEffect, useState } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
 
 import PageHeader from "../../components/PageHeader";
 import AvatarCard from "../../components/persona/AvatarCard";
@@ -66,6 +66,9 @@ const ProfilePage = () => {
             onSettingsPress={() => router.push("/SettingsPage")}
             showSettings
           />
+          <Text style={styles.pageSubtitle}>
+            Track your impact and personalised progress all in one spot.
+          </Text>
         </View>
 
         {/* Growth Journey Card */}
@@ -104,6 +107,11 @@ const styles = StyleSheet.create({
   },
   headerSpacing: {
     marginBottom: layout.sectionSpacing,
+  },
+  pageSubtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: colors.textSecondary,
   },
 });
 

--- a/app/(tabs)/TrackingPage.js
+++ b/app/(tabs)/TrackingPage.js
@@ -36,6 +36,9 @@ const TrackingPage = () => {
       <ScrollView contentContainerStyle={styles.container}>
         <View style={styles.headerSpacing}>
           <PageHeader title="Tracking" />
+          <Text style={styles.pageSubtitle}>
+            Log activities and watch your weekly carbon impact change.
+          </Text>
         </View>
 
         <ImpactChart
@@ -88,6 +91,16 @@ const styles = StyleSheet.create({
   },
   headerSpacing: {
     marginBottom: layout.sectionSpacing,
+  },
+  pageSubtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
+  pageSubtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: colors.textSecondary,
   },
   sectionHeading: {
     fontSize: 16,

--- a/app/OnboardingPage.js
+++ b/app/OnboardingPage.js
@@ -87,7 +87,10 @@ const OnboardingPage = () => {
   }, []);
 
   const activeQuestions = questions.filter((q) => {
-    if (q.question_code === "Q4A" || q.question_code === "Q4B") {
+    const code = q.question_code
+      ? String(q.question_code).toUpperCase()
+      : "";
+    if (code === "Q4A" || code === "Q4B") {
       const drives = answers[4];
       if (drives === false) return false;
     }
@@ -212,14 +215,29 @@ const OnboardingPage = () => {
     const current = currentQuestion;
 
     if (current) {
+      const currentCode = current.question_code
+        ? String(current.question_code).toUpperCase()
+        : "";
       setAnswers((prev) => {
         const updated = { ...prev };
 
-        if (current.question_code === "Q4") {
+        if (currentCode === "Q4") {
           updated[current.question_id] = false;
-          const q4 = questions.find((q) => q.question_code === "Q4");
-          const q4A = questions.find((q) => q.question_code === "Q4A");
-          const q4B = questions.find((q) => q.question_code === "Q4B");
+          const q4 = questions.find(
+            (q) =>
+              q.question_code &&
+              String(q.question_code).toUpperCase() === "Q4"
+          );
+          const q4A = questions.find(
+            (q) =>
+              q.question_code &&
+              String(q.question_code).toUpperCase() === "Q4A"
+          );
+          const q4B = questions.find(
+            (q) =>
+              q.question_code &&
+              String(q.question_code).toUpperCase() === "Q4B"
+          );
           if (q4) updated[q4.question_id] = q4.default_option;
           if (q4A) updated[q4A.question_id] = q4A.default_option;
           if (q4B) updated[q4B.question_id] = q4B.default_option;

--- a/app/OnboardingPage.js
+++ b/app/OnboardingPage.js
@@ -22,6 +22,46 @@ import {
 import colors from "../theme/colors";
 import { hapticError, hapticSuccess } from "../utils/haptics";
 
+const HOUSEHOLD_SIZE_CODES = ["Q2", "HOUSEHOLD_SIZE"];
+const TRANSPORT_CODES = [
+  "Q9",
+  "TRANSPORT_USAGE",
+  "PUBLIC_TRANSPORT_FREQUENCY",
+  "PUBLIC_TRANSPORT",
+];
+
+const getIntegerMinimum = (question) => {
+  if (!question) return 0;
+  if (typeof question.minimum_value === "number") {
+    return Number(question.minimum_value);
+  }
+  if (question.question_code) {
+    const code = String(question.question_code).toUpperCase();
+    if (HOUSEHOLD_SIZE_CODES.includes(code)) {
+      return 1;
+    }
+  }
+  if (question.question_id === 2) {
+    return 1;
+  }
+  return 0;
+};
+
+const isTransportQuestion = (question) => {
+  if (!question) return false;
+  const code = question.question_code
+    ? String(question.question_code).toUpperCase()
+    : "";
+  const text = (question.text_en || question.text || "")
+    .toString()
+    .toLowerCase();
+  return (
+    TRANSPORT_CODES.includes(code) ||
+    code.includes("TRANSPORT") ||
+    text.includes("public transport")
+  );
+};
+
 const OnboardingPage = () => {
   const [questions, setQuestions] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -64,7 +104,17 @@ const OnboardingPage = () => {
   const isAnswerValid = () => {
     if (!currentQuestion) return false;
     const value = answers[currentQuestion.question_id];
-    return validateInput(currentQuestion.input_type, value);
+    const validationOptions =
+      currentQuestion.input_type === "number_int"
+        ? { min: getIntegerMinimum(currentQuestion) }
+        : currentQuestion.input_type === "enum_range" && isTransportQuestion(currentQuestion)
+        ? {}
+        : undefined;
+    return validateInput(
+      currentQuestion.input_type,
+      value,
+      validationOptions
+    );
   };
 
   const handleNext = async () => {

--- a/app/SettingsPage.jsx
+++ b/app/SettingsPage.jsx
@@ -135,7 +135,7 @@ const SettingsPage = () => {
       {/* Privacy & Security */}
       <SettingsCard
         title="Privacy & Security"
-        subtitle="Control your data and security settings"
+        subtitle="View Verde Privacy Policy"
         icon={<SettingsIcon name="shield-checkmark" bgColor={colors.info} />}
         rightContent={<Text style={styles.arrow}>›</Text>}
         onPress={() => setPrivacyVisible(true)}

--- a/app/quizResult.jsx
+++ b/app/quizResult.jsx
@@ -88,14 +88,6 @@ const QuizResultScreen = () => {
     outputRange: [circumference, 0],
   });
 
-  const handleRetry = () => {
-    if (quizData) {
-      router.replace({ pathname: "/QuizScreen", params: { quiz: quizData } });
-    } else {
-      router.back();
-    }
-  };
-
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
@@ -179,7 +171,8 @@ const QuizResultScreen = () => {
           <Text style={styles.feedback}>{feedbackText}</Text>
         </Animated.View>
 
-        <Animated.View style={[styles.buttonWrapper, { opacity: contentAnim }]}
+        <Animated.View
+          style={[styles.buttonWrapper, styles.buttonWrapperLast, { opacity: contentAnim }]}
         >
           <Pressable
             accessibilityRole="button"
@@ -187,24 +180,9 @@ const QuizResultScreen = () => {
               styles.primaryButton,
               pressed && styles.primaryButtonPressed,
             ]}
-            onPress={handleRetry}
-          >
-            <Text style={styles.primaryLabel}>Retry Quiz</Text>
-          </Pressable>
-        </Animated.View>
-
-        <Animated.View
-          style={[styles.buttonWrapper, styles.buttonWrapperLast, { opacity: contentAnim }]}
-        >
-          <Pressable
-            accessibilityRole="button"
-            style={({ pressed }) => [
-              styles.secondaryButton,
-              pressed && styles.secondaryButtonPressed,
-            ]}
             onPress={() => router.push("/LearningPage")}
           >
-            <Text style={styles.secondaryLabel}>Back to Home</Text>
+            <Text style={styles.primaryLabel}>Back to Home</Text>
           </Pressable>
         </Animated.View>
       </View>
@@ -360,22 +338,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "700",
     color: colors.neutral.white,
-  },
-  secondaryButton: {
-    width: "100%",
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: "#E0E0E0",
-    paddingVertical: 16,
-    alignItems: "center",
-  },
-  secondaryButtonPressed: {
-    backgroundColor: "rgba(15,23,42,0.04)",
-  },
-  secondaryLabel: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: "#0F172A",
   },
 });
 

--- a/components/learning/ArticleCard.js
+++ b/components/learning/ArticleCard.js
@@ -201,12 +201,15 @@ const ArticleCardComponent = ({ item, expanded, onToggle, badgeLabel, showThumb 
               </View>
             ) : null}
             <Pressable
-              onPress={handleOpenSource}
-              accessibilityRole="link"
-              accessibilityHint="Opens in browser"
+              onPress={(event) => {
+                event?.stopPropagation?.();
+                handleToggle();
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`${isExpanded ? 'Collapse' : 'Expand'} article ${item.title}`}
               hitSlop={layout.hitSlop}
             >
-              <Text style={styles.title} numberOfLines={2}>
+              <Text style={styles.title} numberOfLines={isExpanded ? undefined : 2}>
                 {item.title}
               </Text>
             </Pressable>
@@ -266,7 +269,7 @@ const ArticleCardComponent = ({ item, expanded, onToggle, badgeLabel, showThumb 
           <Text style={styles.detailMeta}>
             {(item.author || 'Unknown author') + ' • ' + formattedDate + ` • ${item.reading_time_minutes} min`}
           </Text>
-          <Text style={styles.detailTip}>Tap the link or title to read the full article.</Text>
+          <Text style={styles.detailTip}>Tap the link below to read the full article.</Text>
           {domain ? (
             <Pressable
               onPress={handleOpenSource}

--- a/components/persona/AvatarCard/index.js
+++ b/components/persona/AvatarCard/index.js
@@ -25,44 +25,31 @@ const AvatarCard = () => {
     },
     leaf: {
       status: "Sprouting",
-      title: "Your First Leaf",
-      message: "Every journey begins with a single step. Keep going!",
+      title: "Fresh Sprout",
+      message: "Your first shoots are appearing. Keep the momentum going!",
     },
     sapling: {
       status: "Growing Strong",
-      title: "Your Green Guardian",
+      title: "Young Sapling",
       message:
         "Great job! Your sapling is thriving. Stay consistent with your actions.",
     },
     youngPlant: {
       status: "Rising Up",
-      title: "Young Plant Power",
+      title: "Eco Warrior",
       message:
-        "Your efforts are blooming! Keep nurturing your eco-friendly habits.",
-    },
-    tree: {
-      status: "Eco Warrior",
-      title: "Your Flourishing Tree",
-      message:
-        "Amazing! Your tree is fully grown, showing the impact of your sustainable choices.",
+        "Your canopy is taking shape. Keep nurturing those eco-friendly habits.",
     },
     matureTree: {
-      status: "Nature's Guardian",
-      title: "Mature Forest Guardian",
-      message:
-        "Extraordinary! Your mature tree stands tall. You're a true environmental champion.",
-    },
-    finalStage: {
       status: "Climate Legend",
-      title: "Planet Protector",
+      title: "Forest Guardian",
       message:
-        "You've reached the ultimate stage! Your impact is transforming the world. Thank you, Climate Champion!",
+        "You've reached the forest canopy. Your impact is transforming the world. Thank you for leading the change!",
     },
   };
 
   const stage = user?.personaStage || "seed";
-  const { status, title, message } = personaMap[stage];
-
+  const { status, title, message } = personaMap[stage] || personaMap.seed;
   return (
     <LinearGradient
       colors={[colors.eco.green[50], colors.eco.green[100]]}

--- a/components/persona/CarbonPersona/index.js
+++ b/components/persona/CarbonPersona/index.js
@@ -12,7 +12,7 @@ import { StyleSheet, View } from "react-native";
  * Displays Lottie animation for the current persona stage.
  *
  * @param {object} props
- * @param {"seed"|"leaf"|"sapling"|"young-plant"|"tree"|"mature-tree"|"final-stage"} props.stage - Persona stage.
+ * @param {"seed"|"leaf"|"sapling"|"youngPlant"|"matureTree"} props.stage - Persona stage.
  * @returns {JSX.Element}
  */
 const CarbonPersona = ({ stage }) => {
@@ -21,21 +21,14 @@ const CarbonPersona = ({ stage }) => {
     leaf: require("../../../assets/animations/02.json"),
     sapling: require("../../../assets/animations/03.json"),
     youngPlant: require("../../../assets/animations/04.json"),
-    tree: require("../../../assets/animations/05.json"),
     matureTree: require("../../../assets/animations/05.json"),
-    finalStage: require("../../../assets/animations/05.json"),
   };
 
   const animationSource = animationMap[stage] || animationMap.seed;
 
   return (
     <View style={styles.wrapper}>
-      <LottieView
-        source={animationSource}
-        autoPlay
-        loop
-        style={styles.animation}
-      />
+      <LottieView source={animationSource} autoPlay loop style={styles.animation} />
     </View>
   );
 };

--- a/components/profile/ScoreCard/CarbonCard.js
+++ b/components/profile/ScoreCard/CarbonCard.js
@@ -32,6 +32,7 @@ const CarbonCard = ({ data }) => {
   const pointsIntoCurrentRing = points % POINTS_PER_RING;
   const pointsToNextMilestone =
     pointsIntoCurrentRing === 0 ? 0 : POINTS_PER_RING - pointsIntoCurrentRing;
+  const nextStage = pointsToNextMilestone === 0 ? stage : stage + 1;
 
   // 估算碳减排（占位公式）
   const co2SavedKg = Number((points / 18).toFixed(1));
@@ -42,7 +43,7 @@ const CarbonCard = ({ data }) => {
         <Text style={styles.carbon.title}>{data.title}</Text>
 
         <TouchableOpacity
-          style={styles.carbon.shareIcon}
+          style={styles.carbon.shareChip}
           onPress={() => setShowShareModal(true)}
           activeOpacity={0.7}
           accessibilityRole="button"
@@ -53,6 +54,7 @@ const CarbonCard = ({ data }) => {
             size={22}
             color={colors.eco.green[600]}
           />
+          <Text style={styles.carbon.shareText}>Share</Text>
         </TouchableOpacity>
       </View>
 
@@ -63,33 +65,43 @@ const CarbonCard = ({ data }) => {
           <Text style={styles.carbon.pointsLabel}>Carbon Points</Text>
         </View>
 
-        <TreeRingProgress
-          points={points}
-          size={120}
-          strokeWidth={10}
-          maxPerRing={POINTS_PER_RING}
-        >
-          <View style={styles.carbon.stageBadge}>
-            <Text style={styles.carbon.stageBadgeText}>Stage {stage}</Text>
-          </View>
-        </TreeRingProgress>
+        <View style={styles.carbon.avatarColumn}>
+          <TreeRingProgress
+            points={points}
+            size={120}
+            strokeWidth={10}
+            maxPerRing={POINTS_PER_RING}
+          >
+            <View style={styles.carbon.stageBadge}>
+              <Text style={styles.carbon.stageBadgeText}>Stage {stage}</Text>
+            </View>
+          </TreeRingProgress>
+        </View>
       </View>
 
-      <View style={styles.carbon.stageRow}>
-        <Text style={styles.carbon.levelText}>
-          {data.level?.text || levelTier.name}
-        </Text>
-        <Text style={styles.carbon.levelSubtitle}>
+      <View style={styles.carbon.stageDetails}>
+        <Text style={styles.carbon.stageSubtitle}>
           Stage {stage} · {levelTier.min}–
           {levelTier.max === Infinity ? "∞" : levelTier.max} pts
         </Text>
+        <Text style={styles.carbon.progressMessage}>
+          {pointsToNextMilestone > 0
+            ? `Only ${pointsToNextMilestone} pts left for Stage ${nextStage}.`
+            : "Stage unlocked! Keep up the momentum with your next action."}
+        </Text>
       </View>
 
-      <Text style={styles.carbon.progressMessage}>
-        {pointsToNextMilestone > 0
-          ? `Earn ${pointsToNextMilestone} pts more to unlock next stage!`
-          : "Stage unlocked! Keep up the momentum."}
-      </Text>
+      <View style={styles.carbon.infoRow}>
+        <Ionicons
+          name="leaf-outline"
+          size={18}
+          color={colors.eco.green[600]}
+          style={styles.carbon.infoIcon}
+        />
+        <Text style={styles.carbon.infoText}>
+          Earn points by finishing challenges and keeping up with your daily tracking mission.
+        </Text>
+      </View>
 
       {/* Share Poster Modal */}
       <SharePosterModal

--- a/components/profile/ScoreCard/styles.js
+++ b/components/profile/ScoreCard/styles.js
@@ -40,8 +40,9 @@ const base = StyleSheet.create({
 const carbon = StyleSheet.create({
   card: {
     borderRadius: 16,
-    padding: 16,
-    marginBottom: 20,
+    paddingVertical: 16,
+    paddingHorizontal: 14,
+    marginBottom: 12,
     backgroundColor: colors.neutral.white,
     shadowColor: "#000",
     shadowOpacity: 0.05,
@@ -59,38 +60,84 @@ const carbon = StyleSheet.create({
     fontWeight: "700",
     color: colors.textPrimary,
   },
-  shareIcon: {
-    padding: 4,
+  shareChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: "rgba(34, 197, 94, 0.12)",
+  },
+  shareText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.eco.green[600],
+    marginLeft: 6,
   },
   mainRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 8,
+    marginBottom: 6,
   },
-  left: { flex: 1, justifyContent: "center" },
-  right: { justifyContent: "center", alignItems: "center" },
+  pointsContainer: {
+    flex: 1,
+  },
   value: { fontSize: 34, fontWeight: "700", color: colors.textPrimary },
-  percentText: { fontSize: 13, fontWeight: "600", color: colors.textSecondary },
-  stageRow: {
-    marginTop: 12,
+  pointsLabel: {
+    marginTop: 4,
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
+  avatarColumn: {
     alignItems: "center",
   },
-  levelText: {
-    fontSize: 14,
-    fontWeight: "600",
-    color: colors.eco.purple,
+  stageBadge: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: colors.neutral.white,
+    shadowColor: "#000",
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+    marginBottom: 6,
   },
-  levelSubtitle: {
+  stageBadgeText: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: colors.textPrimary,
+  },
+  stageDetails: {
+    alignItems: "center",
+    marginTop: 8,
+  },
+  stageSubtitle: {
     fontSize: 13,
     color: colors.textSecondary,
-    marginTop: 4,
     textAlign: "center",
   },
-  progressMessage: {
-    marginTop: 16,
-    fontSize: 15,
+  infoRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 10,
+    marginTop: 8,
+    borderRadius: 12,
+    backgroundColor: colors.neutral.gray50,
+  },
+  infoIcon: { marginRight: 8 },
+  infoText: {
+    flex: 1,
+    fontSize: 12.5,
+    lineHeight: 17,
     color: colors.textSecondary,
+  },
+  progressMessage: {
+    marginTop: 6,
+    fontSize: 14,
+    fontWeight: "700",
+    color: colors.textPrimary,
     textAlign: "center",
   },
 });

--- a/components/questionnaire/OnboardingHeader/index.js
+++ b/components/questionnaire/OnboardingHeader/index.js
@@ -1,5 +1,6 @@
 import { MaterialIcons } from "@expo/vector-icons";
 import { Text, TouchableOpacity, View } from "react-native";
+import colors from "../../../theme/colors";
 import OnboardingProgressBar from "../OnboardingProgressBar";
 import styles from "./styles";
 
@@ -21,21 +22,56 @@ const OnboardingHeader = ({
   onBack,
   onSkip,
 }) => {
+  const safeTotalSteps = Math.max(Number(totalSteps) || 0, 1);
+  const clampedCurrentStep = Math.min(
+    Math.max(Number(currentStep) || 1, 1),
+    safeTotalSteps
+  );
+  const effectiveCompletedSteps = Math.max(
+    Math.min(Number(completedSteps) || 0, safeTotalSteps),
+    0
+  );
+  const displayStep = clampedCurrentStep || effectiveCompletedSteps || 1;
+
   return (
     <View style={styles.container}>
-      <TouchableOpacity style={styles.backButton} onPress={onBack}>
-        <MaterialIcons name="arrow-back" size={24} color="black" />
-      </TouchableOpacity>
-
-      <TouchableOpacity style={styles.skipButton} onPress={onSkip}>
-        <Text style={styles.skipText}>Skip</Text>
-      </TouchableOpacity>
+      <View style={styles.sideSlot}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={onBack}
+          activeOpacity={0.8}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        >
+          <MaterialIcons
+            name="arrow-back"
+            size={22}
+            color={colors.textPrimary}
+          />
+        </TouchableOpacity>
+      </View>
 
       <View style={styles.progressContainer}>
-        <OnboardingProgressBar progress={completedSteps / totalSteps} />
+        <OnboardingProgressBar progress={displayStep / safeTotalSteps} />
         <Text style={styles.stepText}>
-          {completedSteps}/{totalSteps} completed
+          {displayStep}/{totalSteps} completed
         </Text>
+      </View>
+
+      <View style={[styles.sideSlot, styles.rightSlot]}>
+        <TouchableOpacity
+          style={styles.skipButton}
+          onPress={onSkip}
+          activeOpacity={0.85}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        >
+          <Text style={styles.skipText}>Skip</Text>
+          <MaterialIcons
+            name="chevron-right"
+            size={18}
+            color={colors.eco.green[600]}
+            style={styles.skipIcon}
+          />
+        </TouchableOpacity>
       </View>
     </View>
   );

--- a/components/questionnaire/OnboardingHeader/styles.js
+++ b/components/questionnaire/OnboardingHeader/styles.js
@@ -8,34 +8,39 @@ import colors from "../../../theme/colors";
 export default StyleSheet.create({
   container: {
     width: "100%",
-    paddingVertical: 12,
-    justifyContent: "center",
+    paddingTop: 12,
+    paddingBottom: 8,
+    paddingHorizontal: 16,
+    flexDirection: "row",
     alignItems: "center",
-    position: "relative",
+    backgroundColor: colors.neutral.white,
+  },
+
+  sideSlot: {
+    width: 96,
+    alignItems: "flex-start",
+  },
+
+  rightSlot: {
+    alignItems: "flex-end",
   },
 
   backButton: {
-    position: "absolute",
-    left: 16,
-    top: 12,
-    zIndex: 2,
-  },
-
-  skipButton: {
-    position: "absolute",
-    right: 16,
-    top: 12,
-    zIndex: 2,
-  },
-
-  skipText: {
-    color: colors.eco.blue,
-    fontSize: 14,
-    fontWeight: "500",
+    padding: 10,
+    borderRadius: 20,
+    backgroundColor: colors.neutral.white,
+    borderWidth: 1,
+    borderColor: colors.neutral.gray200,
+    shadowColor: colors.neutral.gray900,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 2,
+    elevation: 2,
   },
 
   progressContainer: {
-    width: "70%",
+    flex: 1,
+    paddingHorizontal: 16,
     alignItems: "center",
   },
 
@@ -45,5 +50,30 @@ export default StyleSheet.create({
     fontWeight: "500",
     color: colors.textSecondary,
     textAlign: "center",
+  },
+
+  skipButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: "rgba(34, 197, 94, 0.14)",
+    shadowColor: colors.eco.green[500],
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+
+  skipText: {
+    color: colors.eco.green[600],
+    fontSize: 15,
+    fontWeight: "600",
+  },
+
+  skipIcon: {
+    marginLeft: 4,
+    marginTop: 1,
   },
 });

--- a/components/questionnaire/QuestionCard/index.js
+++ b/components/questionnaire/QuestionCard/index.js
@@ -31,6 +31,50 @@ const questionIconMap = {
   default: { name: "help-outline", bg: colors.neutral.gray600 },
 };
 
+const TRANSPORT_OPTION_DETAILS = {
+  none: "0 trips per week",
+  never: "0 trips per week",
+  rarely: "Less than once per week",
+  occasional: "1-2 trips per week",
+  occasionally: "1-2 trips per week",
+  weekly: "Once per week",
+  regular: "3-4 trips per week",
+  regularly: "3-4 trips per week",
+  heavy: "5+ trips per week",
+  daily: "5+ trips per week",
+  "daily commute": "5+ trips per week",
+};
+
+const normalizeQuestionCode = (question) =>
+  question?.question_code ? String(question.question_code).toUpperCase() : "";
+
+const isPublicTransportQuestion = (question) => {
+  if (!question) return false;
+  const code = normalizeQuestionCode(question);
+  const text = (question.text_en || question.text || "")
+    .toString()
+    .toLowerCase();
+  return (
+    code.includes("TRANSPORT") ||
+    ["Q9", "TRANSPORT_USAGE", "PUBLIC_TRANSPORT_FREQUENCY"].includes(code) ||
+    question.question_id === 9 ||
+    text.includes("public transport")
+  );
+};
+
+const isHouseholdSizeQuestion = (question) => {
+  if (!question) return false;
+  const code = normalizeQuestionCode(question);
+  const text = (question.text_en || question.text || "")
+    .toString()
+    .toLowerCase();
+  return (
+    ["Q2", "HOUSEHOLD_SIZE"].includes(code) ||
+    question.question_id === 2 ||
+    text.includes("how many people live in your household")
+  );
+};
+
 /**
  * @component QuestionCard
  * @param {Object} props - Component props
@@ -40,26 +84,45 @@ const questionIconMap = {
  * @returns {JSX.Element}
  */
 const QuestionCard = ({ question, value, setValue }) => {
-  const renderInput = () => {
-    switch (question.input_type) {
-      case "number":
-        return (
+  if (!question) {
+    return null;
+  }
+
+	  const transportQuestion = isPublicTransportQuestion(question);
+	  const optionDetails = transportQuestion ? TRANSPORT_OPTION_DETAILS : undefined;
+	  const baseHint =
+	    typeof question.question_hint === "string"
+	      ? question.question_hint.trim()
+      : "";
+  const transportDefinitions = transportQuestion && !baseHint
+    ? "Occasional = 1-2 trips per week. Regular = 3-4 trips per week. Heavy = 5+ trips per week."
+    : "";
+	  const hintText = [baseHint, transportDefinitions].filter(Boolean).join(" ");
+	  const integerMin = isHouseholdSizeQuestion(question) ? 1 : 0;
+
+	  const renderInput = () => {
+	    switch (question.input_type) {
+	      case "number":
+	        return (
           <NumberInput
             value={value}
             onChange={setValue}
-            placeholder="A$ 0.00"
-          />
-        );
-      case "number_int":
-        return <StepperInput value={value} onChange={setValue} min={0} />;
-      case "bool":
-        return <BoolInput value={value} onChange={setValue} />;
+	            placeholder="A$ 0.00"
+	          />
+	        );
+	      case "number_int":
+	        return (
+	          <StepperInput value={value} onChange={setValue} min={integerMin} />
+	        );
+	      case "bool":
+	        return <BoolInput value={value} onChange={setValue} />;
       case "enum_range":
         return (
           <EnumRangeInput
             value={value}
             onChange={setValue}
             options={question.options}
+            optionDetails={optionDetails}
           />
         );
       case "select_enum":
@@ -68,6 +131,7 @@ const QuestionCard = ({ question, value, setValue }) => {
             value={value}
             onChange={setValue}
             options={question.options}
+            optionDetails={optionDetails}
           />
         );
       default:
@@ -93,7 +157,7 @@ const QuestionCard = ({ question, value, setValue }) => {
 
       {renderInput()}
 
-      {question.question_hint && (
+      {hintText && (
         <View style={styles.hintRow}>
           <MaterialIcons
             name="info"
@@ -101,7 +165,7 @@ const QuestionCard = ({ question, value, setValue }) => {
             color={colors.eco.blue}
             style={{ marginTop: 2 }}
           />
-          <Text style={styles.hintText}>{question.question_hint}</Text>
+          <Text style={styles.hintText}>{hintText}</Text>
         </View>
       )}
     </View>

--- a/components/questionnaire/QuestionTypes/EnumRangeInput.js
+++ b/components/questionnaire/QuestionTypes/EnumRangeInput.js
@@ -8,7 +8,27 @@ import { Text, TouchableOpacity, View } from "react-native";
 import colors from "../../../theme/colors";
 import styles from "./styles";
 
-const EnumRangeInput = ({ value, onChange, options = [] }) => {
+const normalizeToUpper = (option) => {
+  if (typeof option !== "string") return option;
+  return option.toUpperCase();
+};
+
+const getDisplayLabel = (option, optionDetails) => {
+  if (typeof option !== "string") return option;
+  const normalizedKey = option.toLowerCase();
+  const detail =
+    optionDetails?.[option] ??
+    (typeof optionDetails?.[normalizedKey] === "string"
+      ? optionDetails[normalizedKey]
+      : undefined);
+  const label = normalizeToUpper(option);
+  if (!detail) return label;
+  const detailLabel =
+    typeof detail === "string" ? detail.toUpperCase() : String(detail).toUpperCase();
+  return `${label} (${detailLabel})`;
+};
+
+const EnumRangeInput = ({ value, onChange, options = [], optionDetails }) => {
   return (
     <View style={styles.enumContainer}>
       {options.map((option, idx) => {
@@ -26,7 +46,9 @@ const EnumRangeInput = ({ value, onChange, options = [] }) => {
               size={20}
               color={selected ? colors.eco.green[600] : colors.neutral.gray600}
             />
-            <Text style={styles.enumOptionText}>{option}</Text>
+            <Text style={styles.enumOptionText}>
+              {getDisplayLabel(option, optionDetails)}
+            </Text>
           </TouchableOpacity>
         );
       })}

--- a/components/questionnaire/QuestionTypes/EnumRangeInput.js
+++ b/components/questionnaire/QuestionTypes/EnumRangeInput.js
@@ -8,9 +8,26 @@ import { Text, TouchableOpacity, View } from "react-native";
 import colors from "../../../theme/colors";
 import styles from "./styles";
 
-const normalizeToUpper = (option) => {
+const isAllCaps = (value) =>
+  typeof value === "string" && value === value.toUpperCase();
+
+const isAllLowerCase = (value) =>
+  typeof value === "string" && value === value.toLowerCase();
+
+const capitalizeFirstLetter = (value) => {
+  if (!value) return value;
+  const lowerValue = value.toLowerCase();
+  return lowerValue.charAt(0).toUpperCase() + lowerValue.slice(1);
+};
+
+const formatOptionLabel = (option) => {
   if (typeof option !== "string") return option;
-  return option.toUpperCase();
+  const trimmed = option.trim();
+  if (!trimmed) return trimmed;
+  if (isAllCaps(trimmed) || isAllLowerCase(trimmed)) {
+    return capitalizeFirstLetter(trimmed);
+  }
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
 };
 
 const getDisplayLabel = (option, optionDetails) => {
@@ -21,10 +38,10 @@ const getDisplayLabel = (option, optionDetails) => {
     (typeof optionDetails?.[normalizedKey] === "string"
       ? optionDetails[normalizedKey]
       : undefined);
-  const label = normalizeToUpper(option);
+  const label = formatOptionLabel(option);
   if (!detail) return label;
   const detailLabel =
-    typeof detail === "string" ? detail.toUpperCase() : String(detail).toUpperCase();
+    typeof detail === "string" ? detail : String(detail);
   return `${label} (${detailLabel})`;
 };
 

--- a/components/questionnaire/QuestionTypes/SelectEnumInput.js
+++ b/components/questionnaire/QuestionTypes/SelectEnumInput.js
@@ -12,9 +12,26 @@ import {
 import colors from "../../../theme/colors";
 import styles from "./styles";
 
-const normalizeToUpper = (option) => {
+const isAllCaps = (value) =>
+  typeof value === "string" && value === value.toUpperCase();
+
+const isAllLowerCase = (value) =>
+  typeof value === "string" && value === value.toLowerCase();
+
+const capitalizeFirstLetter = (value) => {
+  if (!value) return value;
+  const lowerValue = value.toLowerCase();
+  return lowerValue.charAt(0).toUpperCase() + lowerValue.slice(1);
+};
+
+const formatOptionLabel = (option) => {
   if (typeof option !== "string") return option;
-  return option.toUpperCase();
+  const trimmed = option.trim();
+  if (!trimmed) return trimmed;
+  if (isAllCaps(trimmed) || isAllLowerCase(trimmed)) {
+    return capitalizeFirstLetter(trimmed);
+  }
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
 };
 
 const getDisplayLabel = (option, optionDetails) => {
@@ -25,10 +42,10 @@ const getDisplayLabel = (option, optionDetails) => {
     (typeof optionDetails?.[normalizedKey] === "string"
       ? optionDetails[normalizedKey]
       : undefined);
-  const label = normalizeToUpper(option);
+  const label = formatOptionLabel(option);
   if (!detail) return label;
   const detailLabel =
-    typeof detail === "string" ? detail.toUpperCase() : String(detail).toUpperCase();
+    typeof detail === "string" ? detail : String(detail);
   return `${label} (${detailLabel})`;
 };
 

--- a/components/questionnaire/QuestionTypes/SelectEnumInput.js
+++ b/components/questionnaire/QuestionTypes/SelectEnumInput.js
@@ -12,6 +12,26 @@ import {
 import colors from "../../../theme/colors";
 import styles from "./styles";
 
+const normalizeToUpper = (option) => {
+  if (typeof option !== "string") return option;
+  return option.toUpperCase();
+};
+
+const getDisplayLabel = (option, optionDetails) => {
+  if (typeof option !== "string") return option;
+  const normalizedKey = option.toLowerCase();
+  const detail =
+    optionDetails?.[option] ??
+    (typeof optionDetails?.[normalizedKey] === "string"
+      ? optionDetails[normalizedKey]
+      : undefined);
+  const label = normalizeToUpper(option);
+  if (!detail) return label;
+  const detailLabel =
+    typeof detail === "string" ? detail.toUpperCase() : String(detail).toUpperCase();
+  return `${label} (${detailLabel})`;
+};
+
 /**
  * @component SelectEnumInput
  * @description Dropdown selector for select_enum questions with instant close and bounce animation.
@@ -20,8 +40,15 @@ import styles from "./styles";
  * @param {string} props.value - Current selected value
  * @param {Function} props.onChange - Callback when a value is selected
  * @param {string[]} props.options - List of available options
+ * @param {Record<string, string>} [props.optionDetails] - Optional map of option
+ * descriptions keyed by option value (case-insensitive).
  */
-const SelectEnumInput = ({ value, onChange, options = [] }) => {
+const SelectEnumInput = ({
+  value,
+  onChange,
+  options = [],
+  optionDetails,
+}) => {
   const [visible, setVisible] = useState(false);
   const scaleY = useRef(new Animated.Value(0)).current;
 
@@ -60,7 +87,9 @@ const SelectEnumInput = ({ value, onChange, options = [] }) => {
         style={styles.selectBox}
         onPress={() => setVisible(true)}
       >
-        <Text style={styles.selectBoxText}>{value || "Select an option"}</Text>
+        <Text style={styles.selectBoxText}>
+          {value ? getDisplayLabel(value, optionDetails) : "Select an option"}
+        </Text>
         <MaterialIcons
           name="arrow-drop-down"
           size={24}
@@ -98,7 +127,7 @@ const SelectEnumInput = ({ value, onChange, options = [] }) => {
                           selected && styles.dropdownOptionTextSelected,
                         ]}
                       >
-                        {item}
+                        {getDisplayLabel(item, optionDetails)}
                       </Text>
                       {selected && (
                         <MaterialIcons

--- a/components/questionnaire/QuestionTypes/StepperInput.js
+++ b/components/questionnaire/QuestionTypes/StepperInput.js
@@ -1,11 +1,29 @@
+import { useEffect, useRef } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import styles from "./styles";
 
-const StepperInput = ({ value = 1, onChange, min = 1 }) => {
-  const numericValue = Number(value) || 1;
+const StepperInput = ({ value, onChange, min = 1 }) => {
+  const fallback = Number.isFinite(Number(min)) ? Number(min) : 0;
+  const hasValue = value !== null && value !== undefined && value !== "";
+  const parsedValue = Number(value);
+  const numericValue =
+    hasValue && Number.isFinite(parsedValue) ? parsedValue : fallback;
+  const isDecrementDisabled = numericValue <= fallback;
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    if (!hasValue && typeof onChangeRef.current === "function") {
+      onChangeRef.current(fallback);
+    }
+  }, [fallback, hasValue]);
 
   const decrease = () => {
-    if (numericValue > min) onChange(numericValue - 1);
+    if (isDecrementDisabled) return;
+    onChange(numericValue - 1);
   };
 
   const increase = () => {
@@ -17,15 +35,15 @@ const StepperInput = ({ value = 1, onChange, min = 1 }) => {
       <TouchableOpacity
         style={[
           styles.stepperButton,
-          numericValue <= min && styles.stepperButtonDisabled,
+          isDecrementDisabled && styles.stepperButtonDisabled,
         ]}
         onPress={decrease}
-        disabled={numericValue <= min}
+        disabled={isDecrementDisabled}
       >
         <Text
           style={[
             styles.stepperButtonText,
-            numericValue <= min && styles.stepperButtonTextDisabled,
+            isDecrementDisabled && styles.stepperButtonTextDisabled,
           ]}
         >
           -

--- a/components/questionnaire/validation.js
+++ b/components/questionnaire/validation.js
@@ -12,10 +12,10 @@ export const validateNumber = (value) => {
 /**
  * Validates an integer input value (stepper).
  * @param {any} value - Input value to validate
- * @param {number} [min=1] - Minimum allowed value
+ * @param {number} [min=0] - Minimum allowed value
  * @returns {boolean} True if value is an integer >= min
  */
-export const validateInteger = (value, min = 1) => {
+export const validateInteger = (value, min = 0) => {
   if (value === null || value === undefined || value === "") return false;
   const numeric = Number(value);
   return Number.isInteger(numeric) && numeric >= min;
@@ -52,14 +52,15 @@ export const validateSelectEnum = (value) => {
  * General-purpose validation dispatcher.
  * @param {string} inputType - Input type string ("number", "number_int", "bool", "enum_range", "select_enum")
  * @param {any} value - Value to validate
+ * @param {{ min?: number }} [options] - Additional validation options
  * @returns {boolean} True if value passes validation for the input type
  */
-export const validateInput = (inputType, value) => {
+export const validateInput = (inputType, value, options = {}) => {
   switch (inputType) {
     case "number":
       return validateNumber(value);
     case "number_int":
-      return validateInteger(value);
+      return validateInteger(value, options.min);
     case "bool":
       return validateBoolean(value);
     case "enum_range":

--- a/components/rewards/SharePosterModal/index.js
+++ b/components/rewards/SharePosterModal/index.js
@@ -77,12 +77,6 @@ const SharePosterModal = ({
         UTI: "public.png",
       });
 
-      Toast.show({
-        type: "success",
-        text1: "Poster shared successfully!",
-        position: "bottom",
-      });
-
       // Close modal after successful share
       setTimeout(() => {
         onClose();

--- a/components/tracking/LogActivity/LogEnergyActivity.js
+++ b/components/tracking/LogActivity/LogEnergyActivity.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
+  KeyboardAvoidingView,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -34,6 +36,7 @@ const LogEnergyActivity = () => {
   const [electricity, setElectricity] = useState('');
   const [gas, setGas] = useState('');
   const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (energyRecord) {
@@ -47,6 +50,7 @@ const LogEnergyActivity = () => {
   }, [energyRecord]);
 
   const handleSave = async () => {
+    if (submitting) return;
     const electricityValue = parseFloat(electricity) || 0;
     const gasValue = parseFloat(gas) || 0;
 
@@ -55,11 +59,13 @@ const LogEnergyActivity = () => {
       return;
     }
 
+    setSubmitting(true);
     try {
       const result = await logEnergyActivity({ electricityValue, gasValue });
       const pointsEarned = result?.points ?? 0;
       const awarded = result?.awarded ?? pointsEarned > 0;
       const awardError = result?.awardError;
+      setError(null);
 
       if (awardError) {
         showFeedbackToast({
@@ -91,6 +97,13 @@ const LogEnergyActivity = () => {
       });
     } catch (error) {
       console.error('[LogEnergyActivity] Failed to record energy activity:', error);
+      showFeedbackToast({
+        variant: 'error',
+        title: 'Unable to save',
+        message: "We couldn't save your energy activity. Please try again.",
+      });
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -99,95 +112,114 @@ const LogEnergyActivity = () => {
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
-        <TouchableOpacity onPress={handleCancel} style={styles.backButton}>
-          <MaterialIcons name="arrow-back" size={24} color={colors.textPrimary} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Energy Activity</Text>
-      </View>
-
-      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
-        <View style={styles.formContainer}>
-          <View style={styles.noteCard}>
-            <MaterialIcons
-              name="info"
-              size={18}
-              color={colors.eco.blue}
-              style={styles.noteIcon}
-            />
-            <Text style={styles.noteText}>{ENERGY_NOTE}</Text>
-          </View>
-
-          <View style={styles.energySection}>
-            <View style={styles.energyHeader}>
-              <MaterialIcons
-                name="bolt"
-                size={22}
-                color={colors.eco.green[600]}
-                style={styles.energyIcon}
-              />
-              <View>
-                <Text style={styles.energyTitle}>Electricity Bill</Text>
-                <Text style={styles.energySubtitle}>Monthly electricity bill</Text>
-              </View>
-            </View>
-            <View style={styles.inputWrapper}>
-              <Text style={styles.currencyPrefix}>$</Text>
-              <TextInput
-                value={electricity}
-                onChangeText={(text) => {
-                  setElectricity(sanitizeCurrency(text));
-                  setError(null);
-                }}
-                placeholder="e.g., 120"
-                placeholderTextColor={colors.textSecondary}
-                keyboardType="decimal-pad"
-                style={styles.input}
-              />
-            </View>
-          </View>
-
-          <View style={styles.energySection}>
-            <View style={styles.energyHeader}>
-              <MaterialIcons
-                name="local-fire-department"
-                size={22}
-                color="#ef4444"
-                style={styles.energyIcon}
-              />
-              <View>
-                <Text style={styles.energyTitle}>Gas Bill</Text>
-                <Text style={styles.energySubtitle}>Monthly gas bill</Text>
-              </View>
-            </View>
-            <View style={styles.inputWrapper}>
-              <Text style={styles.currencyPrefix}>$</Text>
-              <TextInput
-                value={gas}
-                onChangeText={(text) => {
-                  setGas(sanitizeCurrency(text));
-                  setError(null);
-                }}
-                placeholder="e.g., 80"
-                placeholderTextColor={colors.textSecondary}
-                keyboardType="decimal-pad"
-                style={styles.input}
-              />
-            </View>
-          </View>
-
-          {error ? <Text style={styles.errorText}>{error}</Text> : null}
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={handleCancel} style={styles.backButton}>
+            <MaterialIcons name="arrow-back" size={24} color={colors.textPrimary} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Energy Activity</Text>
         </View>
-      </ScrollView>
 
-      <View style={styles.actions}>
-        <CTAButton label="Save Activity" onPress={handleSave} />
-        <TouchableOpacity style={styles.cancelButton} onPress={handleCancel}>
-          <Text style={styles.cancelText}>Cancel</Text>
-        </TouchableOpacity>
+        <ScrollView
+          style={styles.content}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.formContainer}>
+            <View style={styles.noteCard}>
+              <MaterialIcons
+                name="info"
+                size={18}
+                color={colors.eco.blue}
+                style={styles.noteIcon}
+              />
+              <Text style={styles.noteText}>{ENERGY_NOTE}</Text>
+            </View>
+
+            <View style={styles.energySection}>
+              <View style={styles.energyHeader}>
+                <MaterialIcons
+                  name="bolt"
+                  size={22}
+                  color={colors.eco.green[600]}
+                  style={styles.energyIcon}
+                />
+                <View>
+                  <Text style={styles.energyTitle}>Electricity Bill</Text>
+                  <Text style={styles.energySubtitle}>Monthly electricity bill</Text>
+                </View>
+              </View>
+              <View style={styles.inputWrapper}>
+                <Text style={styles.currencyPrefix}>$</Text>
+                <TextInput
+                  value={electricity}
+                  onChangeText={(text) => {
+                    setElectricity(sanitizeCurrency(text));
+                    setError(null);
+                  }}
+                  placeholder="e.g., 120"
+                  placeholderTextColor={colors.textSecondary}
+                  keyboardType="decimal-pad"
+                  style={styles.input}
+                />
+              </View>
+            </View>
+
+            <View style={styles.energySection}>
+              <View style={styles.energyHeader}>
+                <MaterialIcons
+                  name="local-fire-department"
+                  size={22}
+                  color="#ef4444"
+                  style={styles.energyIcon}
+                />
+                <View>
+                  <Text style={styles.energyTitle}>Gas Bill</Text>
+                  <Text style={styles.energySubtitle}>Monthly gas bill</Text>
+                </View>
+              </View>
+              <View style={styles.inputWrapper}>
+                <Text style={styles.currencyPrefix}>$</Text>
+                <TextInput
+                  value={gas}
+                  onChangeText={(text) => {
+                    setGas(sanitizeCurrency(text));
+                    setError(null);
+                  }}
+                  placeholder="e.g., 80"
+                  placeholderTextColor={colors.textSecondary}
+                  keyboardType="decimal-pad"
+                  style={styles.input}
+                />
+              </View>
+            </View>
+
+            {error ? <Text style={styles.errorText}>{error}</Text> : null}
+          </View>
+        </ScrollView>
+
+        <View style={styles.actions}>
+          <CTAButton
+            label="Save Activity"
+            onPress={handleSave}
+            loading={submitting}
+            disabled={submitting}
+          />
+          <TouchableOpacity
+            style={[styles.cancelButton, submitting && styles.cancelButtonDisabled]}
+            onPress={handleCancel}
+            disabled={submitting}
+          >
+            <Text style={styles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
       </View>
-    </View>
+    </KeyboardAvoidingView>
   );
 };
 
@@ -301,6 +333,9 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     alignItems: 'center',
     marginTop: 12,
+  },
+  cancelButtonDisabled: {
+    opacity: 0.5,
   },
   cancelText: {
     fontSize: 16,

--- a/components/tracking/LogActivity/LogMealActivity.js
+++ b/components/tracking/LogActivity/LogMealActivity.js
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
-  Alert,
+  KeyboardAvoidingView,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -65,8 +66,10 @@ const LogMealActivity = () => {
   const [selectedDiet, setSelectedDiet] = useState(null);
   const [spending, setSpending] = useState('');
   const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
 
   const handleSave = async () => {
+    if (submitting) return;
     const issues = {};
 
     if (!selectedDiet) {
@@ -83,6 +86,7 @@ const LogMealActivity = () => {
       return;
     }
 
+    setSubmitting(true);
     try {
       const result = await logMealActivity({
         dietType: selectedDiet.id,
@@ -128,7 +132,13 @@ const LogMealActivity = () => {
       });
     } catch (error) {
       console.error('[LogMealActivity] Failed to record meal activity:', error);
-      Alert.alert('Unable to save', 'Something went wrong while saving your meal activity. Please try again.');
+      showFeedbackToast({
+        variant: 'error',
+        title: 'Unable to save',
+        message: "We couldn't save your meal activity. Please try again.",
+      });
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -137,76 +147,95 @@ const LogMealActivity = () => {
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
-        <TouchableOpacity onPress={handleCancel} style={styles.backButton}>
-          <MaterialIcons name="arrow-back" size={24} color={colors.textPrimary} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Log Meal Activity</Text>
-      </View>
-
-      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
-        <View style={styles.formContainer}>
-          <Text style={styles.sectionTitle}>Select Diet Type</Text>
-          <Text style={styles.sectionSubtitle}>
-            Required • Choose the best match for today
-          </Text>
-
-          <View style={styles.optionList}>
-            {DIET_OPTIONS.map((option) => {
-              const isActive = selectedDiet?.id === option.id;
-              return (
-                <TouchableOpacity
-                  key={option.id}
-                  style={[styles.optionCard, isActive && styles.optionCardActive]}
-                  onPress={() => {
-                    setSelectedDiet(option);
-                    setErrors((prev) => ({ ...prev, diet: undefined }));
-                  }}
-                >
-                  <View style={[styles.optionIcon, { backgroundColor: `${option.icon.color}1A` }]}> 
-                    <MaterialIcons name={option.icon.name} size={22} color={option.icon.color} />
-                  </View>
-                  <View style={styles.optionCopy}>
-                    <Text style={styles.optionTitle}>{option.title}</Text>
-                    <Text style={styles.optionDescription}>{option.description}</Text>
-                  </View>
-                  <View style={[styles.radioOuter, isActive && styles.radioOuterActive]}>
-                    {isActive && <View style={styles.radioInner} />}
-                  </View>
-                </TouchableOpacity>
-              );
-            })}
-          </View>
-          {errors.diet ? <Text style={styles.errorText}>{errors.diet}</Text> : null}
-
-          <Text style={[styles.sectionTitle, styles.sectionSpacing]}>Meal Spending</Text>
-          <Text style={styles.sectionSubtitle}>Required • How much did you spend on food today?</Text>
-          <View style={styles.spendingInputWrapper}>
-            <Text style={styles.currencyPrefix}>$</Text>
-            <TextInput
-              value={spending}
-              onChangeText={(text) => {
-                setSpending(sanitizeCurrency(text));
-                setErrors((prev) => ({ ...prev, spending: undefined }));
-              }}
-              placeholder="0.00"
-              placeholderTextColor={colors.textSecondary}
-              keyboardType="decimal-pad"
-              style={styles.spendingInput}
-            />
-          </View>
-          {errors.spending ? <Text style={styles.errorText}>{errors.spending}</Text> : null}
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={handleCancel} style={styles.backButton}>
+            <MaterialIcons name="arrow-back" size={24} color={colors.textPrimary} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Log Meal Activity</Text>
         </View>
-      </ScrollView>
 
-      <View style={styles.actions}>
-        <CTAButton label="Save Activity" onPress={handleSave} />
-        <TouchableOpacity style={styles.cancelButton} onPress={handleCancel}>
-          <Text style={styles.cancelText}>Cancel</Text>
-        </TouchableOpacity>
+        <ScrollView
+          style={styles.content}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.formContainer}>
+            <Text style={styles.sectionTitle}>Select Diet Type</Text>
+            <Text style={styles.sectionSubtitle}>
+              Required • Choose the best match for today
+            </Text>
+
+            <View style={styles.optionList}>
+              {DIET_OPTIONS.map((option) => {
+                const isActive = selectedDiet?.id === option.id;
+                return (
+                  <TouchableOpacity
+                    key={option.id}
+                    style={[styles.optionCard, isActive && styles.optionCardActive]}
+                    onPress={() => {
+                      setSelectedDiet(option);
+                      setErrors((prev) => ({ ...prev, diet: undefined }));
+                    }}
+                  >
+                    <View style={[styles.optionIcon, { backgroundColor: `${option.icon.color}1A` }]}>
+                      <MaterialIcons name={option.icon.name} size={22} color={option.icon.color} />
+                    </View>
+                    <View style={styles.optionCopy}>
+                      <Text style={styles.optionTitle}>{option.title}</Text>
+                      <Text style={styles.optionDescription}>{option.description}</Text>
+                    </View>
+                    <View style={[styles.radioOuter, isActive && styles.radioOuterActive]}>
+                      {isActive && <View style={styles.radioInner} />}
+                    </View>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+            {errors.diet ? <Text style={styles.errorText}>{errors.diet}</Text> : null}
+
+            <Text style={[styles.sectionTitle, styles.sectionSpacing]}>Meal Spending</Text>
+            <Text style={styles.sectionSubtitle}>Required • How much did you spend on food today?</Text>
+            <View style={styles.spendingInputWrapper}>
+              <Text style={styles.currencyPrefix}>$</Text>
+              <TextInput
+                value={spending}
+                onChangeText={(text) => {
+                  setSpending(sanitizeCurrency(text));
+                  setErrors((prev) => ({ ...prev, spending: undefined }));
+                }}
+                placeholder="0.00"
+                placeholderTextColor={colors.textSecondary}
+                keyboardType="decimal-pad"
+                style={styles.spendingInput}
+              />
+            </View>
+            {errors.spending ? <Text style={styles.errorText}>{errors.spending}</Text> : null}
+          </View>
+        </ScrollView>
+
+        <View style={styles.actions}>
+          <CTAButton
+            label="Save Activity"
+            onPress={handleSave}
+            loading={submitting}
+            disabled={submitting}
+          />
+          <TouchableOpacity
+            style={[styles.cancelButton, submitting && styles.cancelButtonDisabled]}
+            onPress={handleCancel}
+            disabled={submitting}
+          >
+            <Text style={styles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
       </View>
-    </View>
+    </KeyboardAvoidingView>
   );
 };
 
@@ -350,6 +379,9 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     alignItems: 'center',
     marginTop: 12,
+  },
+  cancelButtonDisabled: {
+    opacity: 0.5,
   },
   cancelText: {
     fontSize: 16,

--- a/components/tracking/LogActivity/LogShoppingActivity.js
+++ b/components/tracking/LogActivity/LogShoppingActivity.js
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import {
+  KeyboardAvoidingView,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -43,8 +45,10 @@ const LogShoppingActivity = () => {
   const router = useRouter();
   const { logShoppingActivity } = useTracking();
 
+  const [expandedSection, setExpandedSection] = useState(SHOPPING_SECTIONS[0]?.id ?? null);
   const [selectedOptions, setSelectedOptions] = useState({});
   const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
 
   const handleSelect = (sectionId, option) => {
     setSelectedOptions((previous) => ({
@@ -52,9 +56,15 @@ const LogShoppingActivity = () => {
       [sectionId]: option,
     }));
     setError(null);
+    setExpandedSection(sectionId);
+  };
+
+  const toggleSection = (sectionId) => {
+    setExpandedSection((previous) => (previous === sectionId ? null : sectionId));
   };
 
   const handleSave = async () => {
+    if (submitting) return;
     const entries = Object.keys(selectedOptions).map((sectionId) => selectedOptions[sectionId]);
 
     if (!entries.length) {
@@ -62,6 +72,7 @@ const LogShoppingActivity = () => {
       return;
     }
 
+    setSubmitting(true);
     try {
       const result = await logShoppingActivity({ entries });
       const pointsEarned = result?.points ?? 0;
@@ -69,6 +80,7 @@ const LogShoppingActivity = () => {
       const awardError = result?.awardError;
 
       setSelectedOptions({});
+      setError(null);
 
       if (awardError) {
         showFeedbackToast({
@@ -100,6 +112,13 @@ const LogShoppingActivity = () => {
       });
     } catch (error) {
       console.error('[LogShoppingActivity] Failed to record shopping activity:', error);
+      showFeedbackToast({
+        variant: 'error',
+        title: 'Unable to save',
+        message: "We couldn't save your shopping activity. Please try again.",
+      });
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -108,64 +127,109 @@ const LogShoppingActivity = () => {
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
-        <TouchableOpacity onPress={handleCancel} style={styles.backButton}>
-          <MaterialIcons name="arrow-back" size={24} color={colors.textPrimary} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Shopping Activity</Text>
-      </View>
-
-      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
-        <View style={styles.formContainer}>
-          {SHOPPING_SECTIONS.map((section) => {
-            const selected = selectedOptions[section.id];
-            return (
-              <View key={section.id} style={styles.sectionCard}>
-                <View style={styles.sectionHeader}>
-                  <View style={styles.sectionIconWrapper}>
-                    <MaterialIcons
-                      name={section.icon}
-                      size={20}
-                      color={colors.textPrimary}
-                    />
-                  </View>
-                  <Text style={styles.sectionTitle}>{section.title}</Text>
-                </View>
-
-                {section.options.map((option) => {
-                  const isActive = selected?.id === option.id;
-                  return (
-                    <TouchableOpacity
-                      key={option.id}
-                      style={[styles.optionCard, isActive && styles.optionCardActive]}
-                      onPress={() => handleSelect(section.id, { ...option, sectionId: section.id })}
-                    >
-                      <View>
-                        <Text style={styles.optionTitle}>{option.label}</Text>
-                        <Text style={styles.optionHelper}>{option.helper}</Text>
-                      </View>
-                      <View style={[styles.radioOuter, isActive && styles.radioOuterActive]}>
-                        {isActive && <View style={styles.radioInner} />}
-                      </View>
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
-            );
-          })}
-
-          {error ? <Text style={styles.errorText}>{error}</Text> : null}
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={handleCancel} style={styles.backButton}>
+            <MaterialIcons name="arrow-back" size={24} color={colors.textPrimary} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Shopping Activity</Text>
         </View>
-      </ScrollView>
 
-      <View style={styles.actions}>
-        <CTAButton label="Save Activity" onPress={handleSave} />
-        <TouchableOpacity style={styles.cancelButton} onPress={handleCancel}>
-          <Text style={styles.cancelText}>Cancel</Text>
-        </TouchableOpacity>
+        <ScrollView
+          style={styles.content}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.formContainer}>
+            {SHOPPING_SECTIONS.map((section) => {
+              const selected = selectedOptions[section.id];
+              const isExpanded = expandedSection === section.id;
+              return (
+                <View key={section.id} style={styles.sectionCard}>
+                  <TouchableOpacity
+                    style={styles.sectionHeader}
+                    onPress={() => toggleSection(section.id)}
+                    activeOpacity={0.8}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${isExpanded ? 'Collapse' : 'Expand'} ${section.title}`}
+                    accessibilityHint="Toggles the spending options for this category"
+                  >
+                    <View style={styles.sectionHeaderContent}>
+                      <View style={styles.sectionIconWrapper}>
+                        <MaterialIcons
+                          name={section.icon}
+                          size={20}
+                          color={colors.textPrimary}
+                        />
+                      </View>
+                      <View style={styles.sectionTitleGroup}>
+                        <Text style={styles.sectionTitle}>{section.title}</Text>
+                        {selected ? (
+                          <Text style={styles.sectionSelected}>
+                            {selected.label}
+                          </Text>
+                        ) : null}
+                      </View>
+                    </View>
+                    <MaterialIcons
+                      name={isExpanded ? 'expand-less' : 'expand-more'}
+                      size={24}
+                      color={colors.textSecondary}
+                    />
+                  </TouchableOpacity>
+
+                  {isExpanded && (
+                    <View style={styles.sectionOptions}>
+                      {section.options.map((option) => {
+                        const isActive = selected?.id === option.id;
+                        return (
+                          <TouchableOpacity
+                            key={option.id}
+                            style={[styles.optionCard, isActive && styles.optionCardActive]}
+                            onPress={() => handleSelect(section.id, { ...option, sectionId: section.id })}
+                          >
+                            <View>
+                              <Text style={styles.optionTitle}>{option.label}</Text>
+                              <Text style={styles.optionHelper}>{option.helper}</Text>
+                            </View>
+                            <View style={[styles.radioOuter, isActive && styles.radioOuterActive]}>
+                              {isActive && <View style={styles.radioInner} />}
+                            </View>
+                          </TouchableOpacity>
+                        );
+                      })}
+                    </View>
+                  )}
+                </View>
+              );
+            })}
+
+            {error ? <Text style={styles.errorText}>{error}</Text> : null}
+          </View>
+        </ScrollView>
+
+        <View style={styles.actions}>
+          <CTAButton
+            label="Save Activity"
+            onPress={handleSave}
+            loading={submitting}
+            disabled={submitting}
+          />
+          <TouchableOpacity
+            style={[styles.cancelButton, submitting && styles.cancelButtonDisabled]}
+            onPress={handleCancel}
+            disabled={submitting}
+          >
+            <Text style={styles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
       </View>
-    </View>
+    </KeyboardAvoidingView>
   );
 };
 
@@ -209,7 +273,13 @@ const styles = StyleSheet.create({
   sectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 12,
+    justifyContent: 'space-between',
+  },
+  sectionHeaderContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    marginRight: 8,
   },
   sectionIconWrapper: {
     width: 32,
@@ -220,10 +290,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginRight: 10,
   },
+  sectionTitleGroup: {
+    flex: 1,
+  },
   sectionTitle: {
     fontSize: 16,
     fontWeight: '600',
     color: colors.textPrimary,
+  },
+  sectionSelected: {
+    fontSize: 12,
+    color: colors.textSecondary,
+    marginTop: 2,
+  },
+  sectionOptions: {
+    marginTop: 12,
   },
   optionCard: {
     flexDirection: 'row',
@@ -283,6 +364,9 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     alignItems: 'center',
     marginTop: 12,
+  },
+  cancelButtonDisabled: {
+    opacity: 0.5,
   },
   cancelText: {
     fontSize: 16,

--- a/components/tracking/LogActivity/LogTransportActivity.js
+++ b/components/tracking/LogActivity/LogTransportActivity.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ScrollView, StyleSheet, Text, View, TouchableOpacity, TextInput } from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View, TouchableOpacity, TextInput } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 
@@ -13,10 +13,6 @@ import { showFeedbackToast, showRewardToast } from '../../../utils/toast';
 const LogTransportActivity = () => {
     const router = useRouter();
     const { logTransportActivity } = useTracking();
-    const [expandedSections, setExpandedSections] = useState({});
-
-    const [selectedTransports, setSelectedTransports] = useState({});
-    const [validationErrors, setValidationErrors] = useState({});
 
     // Ordered transport categories to match design (removed standalone Electric car)
     const transportCategories = [
@@ -77,11 +73,13 @@ const LogTransportActivity = () => {
         }
     ];
 
+    const [expandedSection, setExpandedSection] = useState(transportCategories[0]?.id ?? null);
+    const [selectedTransports, setSelectedTransports] = useState({});
+    const [validationErrors, setValidationErrors] = useState({});
+    const [submitting, setSubmitting] = useState(false);
+
     const toggleSection = (sectionId) => {
-        setExpandedSections(prev => ({
-            ...prev,
-            [sectionId]: !prev[sectionId]
-        }));
+        setExpandedSection((prev) => (prev === sectionId ? null : sectionId));
     };
 
     const updateTransportDistance = (transportId, distance) => {
@@ -123,6 +121,7 @@ const LogTransportActivity = () => {
     };
 
     const saveActivity = async () => {
+        if (submitting) return;
         const validation = validateInputs();
 
         if (validation.hasErrors) {
@@ -136,9 +135,11 @@ const LogTransportActivity = () => {
             return;
         }
 
+        setSubmitting(true);
         try {
             const result = await logTransportActivity(selectedTransports);
             setSelectedTransports({});
+            setValidationErrors({});
 
             const pointsEarned = result?.points ?? 0;
             const awarded = result?.awarded ?? pointsEarned > 0;
@@ -179,13 +180,15 @@ const LogTransportActivity = () => {
                 title: 'Unable to save',
                 message: "We couldn't save your transport activity. Please try again.",
             });
+        } finally {
+            setSubmitting(false);
         }
     };
 
     const renderTransportOption = (category, isSubcategory = false) => {
-        const isExpanded = expandedSections[category.id];
-        const hasSubcategories = category.subcategories && category.subcategories.length > 0;
-        const hasError = validationErrors[category.id];
+        const isExpanded = !isSubcategory && expandedSection === category.id;
+        const hasSubcategories = Array.isArray(category.subcategories) && category.subcategories.length > 0;
+        const hasError = isSubcategory ? validationErrors[category.id] : null;
 
         return (
             <View key={category.id}>
@@ -223,20 +226,22 @@ const LogTransportActivity = () => {
                     {/* Distance input for subcategories (actual transport modes) */}
                     {isSubcategory ? (
                         <View style={styles.distanceInputSection}>
-                            <TextInput
+                            <View
                                 style={[
-                                    styles.inlineDistanceInput,
-                                    hasError && styles.inputError
+                                    styles.distanceInputContainer,
+                                    hasError && styles.distanceInputError
                                 ]}
-                                placeholder="km"
-                                placeholderTextColor={colors.textSecondary}
-                                value={selectedTransports[category.id] || ''}
-                                onChangeText={(text) => updateTransportDistance(category.id, text)}
-                                keyboardType="numeric"
-                            />
-                            {category.zeroEmission ? (
-                                <Text style={styles.zeroEmissionNote}>0 kg CO₂</Text>
-                            ) : null}
+                            >
+                                <TextInput
+                                    style={styles.distanceInputField}
+                                    placeholder="0"
+                                    placeholderTextColor={colors.textSecondary}
+                                    value={selectedTransports[category.id] || ''}
+                                    onChangeText={(text) => updateTransportDistance(category.id, text)}
+                                    keyboardType="numeric"
+                                />
+                                <Text style={styles.distanceUnit}>km</Text>
+                            </View>
                         </View>
                     ) : (
                         hasSubcategories && (
@@ -255,6 +260,20 @@ const LogTransportActivity = () => {
                 )}
 
                 {hasSubcategories && isExpanded && (
+                    <View style={styles.sectionHintRow}>
+                        <MaterialIcons
+                            name="info-outline"
+                            size={16}
+                            color={colors.textSecondary}
+                            style={styles.sectionHintIcon}
+                        />
+                        <Text style={styles.sectionHintText}>
+                            Enter distance in kilometres (numbers only).
+                        </Text>
+                    </View>
+                )}
+
+                {hasSubcategories && isExpanded && (
                     <View style={styles.subcategoriesContainer}>
                         {category.subcategories.map(subcategory =>
                             renderTransportOption(subcategory, true)
@@ -264,57 +283,71 @@ const LogTransportActivity = () => {
             </View>
         );
     };
-
-
-
     return (
-        <View style={styles.container}>
-            <View style={styles.headerSpacing}>
-                <PageHeader title="Log Transport Activity" showBack />
-            </View>
+        <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+            keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+        >
+            <View style={styles.container}>
+                <View style={styles.headerSpacing}>
+                    <PageHeader
+                        title="Log Transport Activity"
+                        showBack
+                        onBackPress={() => router.replace('/(tabs)/TrackingPage')}
+                    />
+                </View>
 
-            <ScrollView
-                style={styles.content}
-                contentContainerStyle={{ paddingBottom: layout.blockSpacing }}
-                showsVerticalScrollIndicator={false}
-            >
-                <View style={styles.formContainer}>
-                    <Text style={styles.sectionTitle}>Transport Trip</Text>
+                <ScrollView
+                    style={styles.content}
+                    contentContainerStyle={{ paddingBottom: layout.blockSpacing }}
+                    showsVerticalScrollIndicator={false}
+                    keyboardShouldPersistTaps="handled"
+                >
+                    <View style={styles.formContainer}>
+                        <Text style={styles.sectionTitle}>Transport Trip</Text>
 
-                    <View style={styles.selectContainer}>
-                        <Text style={styles.selectLabel}>
-                            Select Transport Mode <Text style={styles.required}>*</Text>
-                        </Text>
+                        <View style={styles.selectContainer}>
+                            <Text style={styles.selectLabel}>
+                                Select Transport Mode <Text style={styles.required}>*</Text>
+                            </Text>
 
-                        {/* Transport Options - Always Visible */}
-                        <View style={styles.transportList}>
-                            {transportCategories.map(category =>
-                                renderTransportOption(category)
-                            )}
+                            {/* Transport Options - Always Visible */}
+                            <View style={styles.transportList}>
+                                {transportCategories.map(category =>
+                                    renderTransportOption(category)
+                                )}
+                            </View>
                         </View>
                     </View>
-                </View>
-            </ScrollView>
+                </ScrollView>
 
-            {/* Action Buttons */}
-            <View style={styles.actionButtons}>
-                <CTAButton
-                    label="Save Activity"
-                    onPress={saveActivity}
-                    style={styles.saveButton}
-                />
-                <TouchableOpacity
-                    style={styles.cancelButton}
-                    accessibilityRole='button'
-                    accessibilityLabel='Cancel logging transport activity'
-                    accessibilityHint='Returns to the tracking tab without saving'
-                    hitSlop={layout.hitSlop}
-                    onPress={() => router.back()}
-                >
-                    <Text style={styles.cancelText}>Cancel</Text>
-                </TouchableOpacity>
+                {/* Action Buttons */}
+                <View style={styles.actionButtons}>
+                    <CTAButton
+                        label="Save Activity"
+                        onPress={saveActivity}
+                        style={styles.saveButton}
+                        loading={submitting}
+                        disabled={submitting}
+                    />
+                    <TouchableOpacity
+                        style={[styles.cancelButton, submitting && styles.cancelButtonDisabled]}
+                        accessibilityRole='button'
+                        accessibilityLabel='Cancel logging transport activity'
+                        accessibilityHint='Closes the transport log without saving'
+                        hitSlop={layout.hitSlop}
+                        onPress={() => {
+                            if (submitting) return;
+                            router.back();
+                        }}
+                        disabled={submitting}
+                    >
+                        <Text style={styles.cancelText}>Cancel</Text>
+                    </TouchableOpacity>
+                </View>
             </View>
-        </View>
+        </KeyboardAvoidingView>
     );
 };
 
@@ -367,7 +400,7 @@ const styles = StyleSheet.create({
     },
     subcategoryOption: {
         paddingLeft: layout.cardSpacing * 2,
-        backgroundColor: colors.neutral.gray50,
+        backgroundColor: colors.neutral.white,
     },
     selectedOption: {
         backgroundColor: colors.eco.green[50],
@@ -395,33 +428,63 @@ const styles = StyleSheet.create({
     },
     distanceInputSection: {
         marginLeft: 12,
-        alignItems: 'center',
+        alignItems: 'flex-end',
     },
-    inlineDistanceInput: {
-        backgroundColor: colors.neutral.gray50,
+    distanceInputContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: colors.neutral.white,
         borderRadius: 8,
+        borderWidth: 1,
+        borderColor: colors.neutral.gray200,
         paddingHorizontal: 12,
-        paddingVertical: 8,
+        paddingVertical: 6,
+        minWidth: 96,
+        shadowColor: '#000',
+        shadowOpacity: 0.05,
+        shadowRadius: 4,
+        shadowOffset: { width: 0, height: 2 },
+        elevation: 1,
+    },
+    distanceInputField: {
+        flex: 1,
         fontSize: 14,
         color: colors.textPrimary,
-        width: 80,
         textAlign: 'center',
+        paddingVertical: 0,
     },
-    zeroEmissionNote: {
-        fontSize: 12,
-        color: colors.success,
-        marginTop: 6,
+    distanceUnit: {
+        fontSize: 13,
+        color: colors.textSecondary,
+        marginLeft: 4,
     },
-    inputError: {
+    distanceInputError: {
         borderColor: colors.error,
-        borderWidth: 1,
     },
     errorText: {
         fontSize: 12,
         color: colors.error,
-        marginLeft: 44,
+        marginLeft: layout.cardSpacing * 2,
         marginTop: 4,
         marginBottom: 8,
+    },
+    sectionHintRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: colors.neutral.gray50,
+        marginHorizontal: layout.cardSpacing,
+        marginTop: 12,
+        paddingHorizontal: layout.cardSpacing,
+        paddingVertical: 8,
+        borderRadius: 10,
+    },
+    sectionHintIcon: {
+        marginRight: 8,
+    },
+    sectionHintText: {
+        flex: 1,
+        fontSize: 12,
+        color: colors.textSecondary,
     },
     subcategoriesContainer: {
         backgroundColor: colors.neutral.white,
@@ -440,6 +503,9 @@ const styles = StyleSheet.create({
         borderRadius: 12,
         paddingVertical: layout.cardSpacing,
         alignItems: 'center',
+    },
+    cancelButtonDisabled: {
+        opacity: 0.5,
     },
     cancelText: {
         fontSize: 16,

--- a/context/TrackingContext.js
+++ b/context/TrackingContext.js
@@ -331,10 +331,12 @@ const getMonthInfo = () => {
 export const TrackingProvider = ({ children }) => {
   const { user, addCarbonPoints } = useUser();
 
-  const [weeklyImpact, setWeeklyImpact] = useState(() => {
+  const buildInitialWeeklyImpact = useCallback(() => {
     const baseline = baseWeeklyImpact.baseline ?? 0;
     const template = mergeTrendWithTemplate(baseWeeklyImpact.trend);
-    const total = clampToStep(template.reduce((sum, point) => sum + (point.value ?? 0), 0));
+    const total = clampToStep(
+      template.reduce((sum, point) => sum + (point.value ?? 0), 0)
+    );
     const saved = clampToStep(Math.max(baseline - total, 0));
 
     return {
@@ -345,14 +347,21 @@ export const TrackingProvider = ({ children }) => {
       total,
       saved,
     };
-  });
+  }, []);
+
+  const buildInitialActivities = useCallback(
+    (source) => (source ?? []).map((activity) => ({ ...activity })),
+    []
+  );
+
+  const [weeklyImpact, setWeeklyImpact] = useState(buildInitialWeeklyImpact);
 
   const [todaysActivities, setTodaysActivities] = useState(() =>
-    (baseTodaysActivities ?? []).map((activity) => ({ ...activity }))
+    buildInitialActivities(baseTodaysActivities)
   );
 
   const [longTermActivities, setLongTermActivities] = useState(() =>
-    (baseLongTermActivities ?? []).map((activity) => ({ ...activity }))
+    buildInitialActivities(baseLongTermActivities)
   );
 
   const categoryTotalsRef = useRef({
@@ -373,6 +382,28 @@ export const TrackingProvider = ({ children }) => {
   const [rewardMapping, setRewardMapping] = useState({
     ...DEFAULT_REWARD_MAPPING,
   });
+
+  useEffect(() => {
+    // Reset tracking state whenever a different user signs in
+    setWeeklyImpact(buildInitialWeeklyImpact());
+    setTodaysActivities(buildInitialActivities(baseTodaysActivities));
+    setLongTermActivities(buildInitialActivities(baseLongTermActivities));
+
+    categoryTotalsRef.current = {
+      [CATEGORY_KEYS.transport]: 0,
+      [CATEGORY_KEYS.meals]: 0,
+      [CATEGORY_KEYS.shopping]: 0,
+    };
+    categoryDayRef.current = {
+      [CATEGORY_KEYS.transport]: null,
+      [CATEGORY_KEYS.meals]: null,
+      [CATEGORY_KEYS.shopping]: null,
+    };
+    shoppingSpendRef.current = 0;
+    shoppingSpendDayRef.current = null;
+    setEnergyRecord(null);
+    setRewardMapping({ ...DEFAULT_REWARD_MAPPING });
+  }, [buildInitialActivities, buildInitialWeeklyImpact, user?.eco_id]);
 
   const applyDailySnapshotToActivities = useCallback((totals = {}) => {
     setTodaysActivities((previous) =>

--- a/context/UserContext.js
+++ b/context/UserContext.js
@@ -12,25 +12,22 @@ const UserContext = createContext(null);
 /**
  * Derives persona stage from carbon points based on levelTiers.
  * Maps 7 animation stages to the tier system:
- * - seed: Seedling (0-99)
- * - leaf: Sprout (100-249)
- * - sapling: Young Sapling (250-499)
- * - youngPlant: Eco Warrior (500-749)
- * - tree: Forest Guardian (750-999)
- * - matureTree: Blooming Grove (1000-1999)
- * - finalStage: Earth Ally+ (2000+)
+ * Maps broader carbon point bands to the five persona animation stages.
+ * - seed: 0-99 pts (Seedling)
+ * - leaf: 100-249 pts (Sprout)
+ * - sapling: 250-499 pts (Young Sapling)
+ * - youngPlant: 500-749 pts (Eco Warrior)
+ * - matureTree: 750+ pts (Forest Guardian and beyond)
  *
  * @param {number} carbonPoints - Current user carbon points.
  * @returns {"seed"|"leaf"|"sapling"|"youngPlant"|"tree"|"matureTree"|"finalStage"} Persona stage string.
  */
 const derivePersonaStage = (carbonPoints) => {
   if (!carbonPoints || carbonPoints <= 99) return "seed";
-  if (carbonPoints <= 199) return "leaf";
-  if (carbonPoints <= 299) return "sapling";
-  if (carbonPoints <= 399) return "youngPlant";
-  if (carbonPoints <= 499) return "tree";
-  if (carbonPoints <= 599) return "matureTree";
-  return "finalStage";
+  if (carbonPoints <= 249) return "leaf";
+  if (carbonPoints <= 499) return "sapling";
+  if (carbonPoints <= 749) return "youngPlant";
+  return "matureTree";
 };
 
 /**


### PR DESCRIPTION
Transport logging flow: cancel/back routes now return to Tracking without jumping tabs (P0 fix), accordion sections collapse others, zero-emission text for bike/walk removed, white pill inputs plus section hint tidied the UI, and all log forms (transport/meals/shopping/energy) gained loading states, keyboard-safe layouts, and disabled cancel while saving.
Learning tab: interactions unified under a single handler/pattern so the page header and subtitle behave consistently (P1 note).
Questionnaire: household stepper now enforces a minimum of one person, options render in uppercase everywhere, and public transport hints were clarified.
Quiz results: removed the unsupported Retry button and made “Back to Home” the single green CTA.
Primary tabs (Profile, Tracking, Challenges, Learning) now show a short purpose line under the title for quick context.